### PR TITLE
EP-42371: Code changes to reduce spacing in docker registry ui tag hi…

### DIFF
--- a/src/components/tag-history/image-label.riot
+++ b/src/components/tag-history/image-label.riot
@@ -99,7 +99,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     :host {
       display: block;
-      padding: 20px;
+      padding: 5px;
       min-width: 100px;
       min-height: 3em;
       width: auto;


### PR DESCRIPTION
Why this change was made -
These changes are related to to reduce spacing on docker registry ui - tag history. For details - [Link](https://netskope.atlassian.net/browse/EP-42371)

What is the change -
Change is reduce the spacing from 20px to 5x

Testing -
PFA
<img width="1451" alt="Screenshot 2024-04-26 at 12 18 04 PM" src="https://github.com/Joxit/docker-registry-ui/assets/151713372/96ab0582-8e67-4d39-b5e2-4d9f0d7df4d1">
