### PR TITLE
EP-42371: Code changes to identify and mark images as deprecated

### DIFF
--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -32,7 +32,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <material-waves if="{ state.images }" center="true" color="#ddd"></material-waves>
       <span>
         <i class="material-icons">send</i>
-        { state.image || state.repo }
+        { state.image || state.repo } <span if="{ checkImage(state.image) }" class="github-label label-red">deprecated</span>
         <div if="{state.images}" class="item-count right">
           { state.nImages } images
           <i class="material-icons animated {state.expanded ? 'expanded' : ''}">expand_more</i>
@@ -57,11 +57,29 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       item="{ item }"
     ></catalog-element>
   </div>
+  <style>
+  .github-label {
+  display: inline-block;
+  padding: 4px 8px;
+  margin-left: 20px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 4px;
+  }
+  .label-red {
+  color: #fff;
+  background-color: #d73a49; /* Red color used by GitHub */
+  }
+  .label-green {
+  color: #fff;
+  background-color: #28a745; /* Green color used by GitHub */
+  }
+  </style>
   <script>
     import router from '../../scripts/router';
     import { Http } from '../../scripts/http';
     import { matchSearch } from '../search-bar.riot';
-
+    import * as data from './renovate-replacements-v2.json';
     export default {
       onBeforeMount(props, state) {
         if (props.item.images && props.item.images.length === 1) {
@@ -105,6 +123,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           }, 50);
         }
       },
+
+      checkImage(image) {
+        console.log("checking image :- ", image);
+        const keys = new Set();
+        for (const key in data.default) {
+          if (key.includes("ns-ep") || key.includes("ns-builder")) {
+            console.log(`${key}`);
+            keys.add(key);
+          }
+        }
+        if (keys.has(image)) {
+          return true;
+        } 
+        return false;
+      },
+
       getNbTags(props, state) {
         const self = this;
         const oReq = new Http({

--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -80,7 +80,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import { Http } from '../../scripts/http';
     import { matchSearch } from '../search-bar.riot';
     import * as data from './renovate-replacements-v2.json';
-    export default {
+
+    let keys = new Set();
+    export default {      
       onBeforeMount(props, state) {
         if (props.item.images && props.item.images.length === 1) {
           state.image = props.item.images[0];
@@ -97,6 +99,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       onMounted(props, state) {
+        this.fetchData();
         const materialCard = this.$('material-card');
         if (materialCard) {
           materialCard.style['z-index'] = props.zIndex;
@@ -123,22 +126,28 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           }, 50);
         }
       },
-
-      checkImage(image) {
-        console.log("checking image :- ", image);
-        const keys = new Set();
+      fetchData() {
         for (const key in data.default) {
           if (key.includes("ns-ep") || key.includes("ns-builder")) {
-            console.log(`${key}`);
             keys.add(key);
           }
         }
-        if (keys.has(image)) {
-          return true;
-        } 
+        console.log(keys);
+      },
+      checkImage(image) {
+        console.log("checking image :- ", image);
+        if (image) {
+          if (image.includes("-recent")){
+            return true;
+          }
+        }
+        for (const key of keys) {
+          if (key.includes(image)) {
+            return true;
+          }
+        }
         return false;
       },
-
       getNbTags(props, state) {
         const self = this;
         const oReq = new Http({

--- a/src/components/catalog/renovate-replacements-v2.json
+++ b/src/components/catalog/renovate-replacements-v2.json
@@ -1,0 +1,501 @@
+{
+    "artifactory-rd.netskope.io/dockerhub/cytopia/ansible-lint:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/dockerhub-cytopia-ansible-lint-current",
+        "sha": "sha256:534b50ae23642ba514298eae1b647f14d0fcb0433b13a5da30683a9a4288a74e",
+        "tag": "24.84.3007"
+    },
+    "artifactory-rd.netskope.io/drone-plugins/artifactory-docker:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/drone-plugins-artifactory-docker-current",
+        "sha": "sha256:9a145384a384fd65d4b37b272fd9aee376849c231411875cf17634c0713f4365",
+        "tag": "24.84.3006"
+    },
+    "artifactory-rd.netskope.io/drone-plugins/artifactory-helm:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/artifactory-helm-current",
+        "sha": "sha256:ad2ce99e5851e7d2ca836a559a1828988e31e8666b12e3054b393dd13979b6f6",
+        "tag": "24.83.252"
+    },
+    "artifactory-rd.netskope.io/drone-plugins/asa-trivy:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/trivy",
+        "sha": "sha256:04b4611db58af07185f729e2a63a99dc3e1c862f4d6c5b789d450545b217565d",
+        "tag": "0.50.4"
+    },
+    "artifactory-rd.netskope.io/drone-plugins/docker-dind:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/docker-dind-current",
+        "sha": "sha256:f28e393181ef769cd6d570d41c6e25b3b5acb8d734da84378d3b85a8ab58fb52",
+        "tag": "24.84.3006"
+    },
+    "artifactory-rd.netskope.io/drone-plugins/dockerizer:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/drone-plugins-dockerizer-current",
+        "sha": "sha256:b3ff0703473b9aa00089f96d0391118b922f4677afad26270b6cc857c80cce10",
+        "tag": "24.84.3006"
+    },
+    "artifactory-rd.netskope.io/drone-plugins/drone-cache-gcs:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/drone-cache-gcs-current",
+        "sha": "sha256:dd6375583efe63ffd5d4b64c7bcaa9126429c0013440b327d1eedb9a0eadec2a",
+        "tag": "24.84.3006"
+    },
+    "artifactory-rd.netskope.io/ep-tools-docker/develop/python3.8:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/develop-python3-8",
+        "sha": "sha256:4037f734300708bedf6a21963392f2a0e782e4dc998c368ad94513b830d1f8b5",
+        "tag": "24.84.3004"
+    },
+    "artifactory-rd.netskope.io/ep-tools-docker/develop/trivy:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/trivy",
+        "sha": "sha256:04b4611db58af07185f729e2a63a99dc3e1c862f4d6c5b789d450545b217565d",
+        "tag": "0.50.4"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-builder/image-develop-python3-8:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/develop-python3-8",
+        "sha": "sha256:4037f734300708bedf6a21963392f2a0e782e4dc998c368ad94513b830d1f8b5",
+        "tag": "24.84.3004"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/actions-runner-dind-2004-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/actions-runner-dind-2004-current",
+        "sha": "sha256:31433fbb61ed912076ac7ad948298204e7c5bea05ff3beed1b2c1d7efe9616d5",
+        "tag": "24.84.298"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/buf:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/buf",
+        "sha": "sha256:a44bff005a698a491dffdc58d29974eaff51a0279aa9432482bddd6b74ba47d3",
+        "tag": "1.31.0"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/codeclimate-duplication-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/codeclimate-duplication-current",
+        "sha": "sha256:864b99c47545e2a1320a28bd2e655ec9bea68fb09856597a00548297ab116b51",
+        "tag": "24.82.236"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/dragonfly-operator-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/dragonfly-operator-current",
+        "sha": "sha256:2d331ef2dbe00a0a20f76d9a0a02381ee6cf0e219fa233d8112c1e55d9242f22",
+        "tag": "24.84.3017"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/dragonflydb-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/dragonflydb-current",
+        "sha": "sha256:9f39384387f98a38bd9a3321a236ca63a469333d4f80236503c32177694655f6",
+        "tag": "24.84.3017"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/git-alpine-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/git-alpine-current",
+        "sha": "sha256:c7b7b922defa00476f0bb4c776961325d9fe4353d73f3b574ff231f59220e7c0",
+        "tag": "24.84.290"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/golang-alpine-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/golang-alpine-current",
+        "sha": "sha256:45d75cd66550c6ebdc8603860e216bed8ca60d28f54c7735003c7f98f362d574",
+        "tag": "24.84.208"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/golang-alpine-recent:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/golang-alpine-current",
+        "sha": "sha256:45d75cd66550c6ebdc8603860e216bed8ca60d28f54c7735003c7f98f362d574",
+        "tag": "24.84.208"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/golangci-lint-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/golangci-lint-current",
+        "sha": "sha256:f2e5ea5e756a3e43b5ae90fcfbf3e6025ea0d4d9594c0c653e22a4a0433852b1",
+        "tag": "24.83.262"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/gradle-jdk18-alpine-recent:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/gradle-alpine-current",
+        "sha": "sha256:d8934b33c387b82520fdb11685eb9fa1b121fc35b3c920ae6a10c1e038467ac2",
+        "tag": "24.82.236"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/mongo:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/mongo-current",
+        "sha": "sha256:1aef36546854957a453d5a363cada820567299120521fed63891b77869b6d0a0",
+        "tag": "24.84.3017"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/pipelinecomponents-yamllint-current:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/pipelinecomponents-yamllint-current",
+        "sha": "sha256:398bca084cdc07bf62f50f9eb2781b8d67c243fde6c25e819e224cf93357905c",
+        "tag": "24.84.298"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/terraform:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/terraform",
+        "sha": "sha256:3da18e37498014338c73cba3949792030fc2aa4c679aaadb9ea38f7a60fc7915",
+        "tag": "1.8.2"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/trivy:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/trivy",
+        "sha": "sha256:04b4611db58af07185f729e2a63a99dc3e1c862f4d6c5b789d450545b217565d",
+        "tag": "0.50.4"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/vanilla-alpine-recent:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/vanilla-alpine-current",
+        "sha": "sha256:6c9a56296afeb732ed08c343d095576e0892a3e51a4e49ce168a527ea8caaa5b",
+        "tag": "24.82.235"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/yamllint:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/yamllint",
+        "sha": "sha256:65c83e66789b0fb03f91f30a5897768e38a46a08d08c1759c6845d6a45331c75",
+        "tag": "1.26.3"
+    },
+    "artifactory-rd.netskope.io/org-base-release-docker/ns-ep/yq:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/yq",
+        "sha": "sha256:9cb9492ba78de24ae8190541dc9903d43b9bfd740b009c8649e1932a0e462c65",
+        "tag": "4.43.1"
+    },
+    "artifactory-rd.netskope.io/pe-docker/ns-ubuntu-1604-fips:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-pe-docker/ep-ns-ubuntu-1604-fips",
+        "sha": "sha256:eb9bb8a0ede1dd41c92a4a4f7af31282df1d1c12dfe351250b6921126e0e8ce7",
+        "tag": "24.82.1"
+    },
+    "artifactory-rd.netskope.io/pe-docker/ns-ubuntu-1604:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-pe-docker/ep-ns-ubuntu-1604",
+        "sha": "sha256:24fc95c94718496a20ab4c1f31d548d19a3bfa70ad6bcbe1a5d2113355da1d81",
+        "tag": "24.82.1"
+    },
+    "artifactory-rd.netskope.io/pe-docker/ns-ubuntu-2004-fips:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-pe-docker/ep-ns-ubuntu-2004-fips",
+        "sha": "sha256:cac54faba0d31a6da8570da871680d2232980e65ef97a89ab4a2a080262008fd",
+        "tag": "24.84.10"
+    },
+    "artifactory-rd.netskope.io/pe-docker/ns-ubuntu-2004:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-pe-docker/ep-ns-ubuntu-2004",
+        "sha": "sha256:b898ee881b72dd6fbf2d18fb8ef051e7a78bc53ac259379f62c0358fdef549fb",
+        "tag": "24.84.10"
+    },
+    "artifactory-rd.netskope.io/phoenix-dev/nscodeclimateparser:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/phoenix-dev-nscodeclimateparser-current",
+        "sha": "sha256:9de8526c502ef477c4ca8f60d52cc01f74b9eb2187336e141c50d113c500b8ba",
+        "tag": "24.83.243"
+    },
+    "docker.dragonflydb.io/dragonflydb/operator:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/dragonfly-operator-current",
+        "sha": "sha256:2d331ef2dbe00a0a20f76d9a0a02381ee6cf0e219fa233d8112c1e55d9242f22",
+        "tag": "24.84.3017"
+    },
+    "ghcr.io/containerbase/sidecar:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/sidecar-current",
+        "sha": "sha256:55cc887e515da2be122b9996b6b4a6e18a3abea32c6f5c7a2c7191dff557c7a7",
+        "tag": "24.84.3017"
+    },
+    "ghcr.io/dragonflydb/dragonfly:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/dragonflydb-current",
+        "sha": "sha256:9f39384387f98a38bd9a3321a236ca63a469333d4f80236503c32177694655f6",
+        "tag": "24.84.3017"
+    },
+    "index.docker.io/alpine/helm:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/helm-alpine-current",
+        "sha": "sha256:d28db63f597582e91f74933b7fd005032bf26cedd637c3536d46e8e267294a6e",
+        "tag": "24.84.255"
+    },
+    "index.docker.io/alpine:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/vanilla-alpine-current",
+        "sha": "sha256:6c9a56296afeb732ed08c343d095576e0892a3e51a4e49ce168a527ea8caaa5b",
+        "tag": "24.82.235"
+    },
+    "index.docker.io/amd64/ubuntu:22.04": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-pe-docker/ep-ns-ubuntu-2204",
+        "sha": "sha256:0620eb730c5bb7d358a905f44c7cd005514a4ab422275c2cadcf56b15bb5f040",
+        "tag": "1.86"
+    },
+    "index.docker.io/aquasec/trivy:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/trivy",
+        "sha": "sha256:04b4611db58af07185f729e2a63a99dc3e1c862f4d6c5b789d450545b217565d",
+        "tag": "0.50.4"
+    },
+    "index.docker.io/bitnami/kubectl:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/bitnami-kubectl-current",
+        "sha": "sha256:8c1478d8a5442d90d6dba7ff070c5a648e9944613d40dd8d63d38bc5a578637d",
+        "tag": "24.84.3012"
+    },
+    "index.docker.io/brunneis/python:3.8": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/ubuntu-2004-python-3-8",
+        "sha": "sha256:f844f1cd1611fc1f3ccc78a9ceec3eeb33500ef8291a6bc6010cf9fda1cb1be1",
+        "tag": "24.84.3002"
+    },
+    "index.docker.io/bufbuild/buf:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/buf",
+        "sha": "sha256:a44bff005a698a491dffdc58d29974eaff51a0279aa9432482bddd6b74ba47d3",
+        "tag": "1.31.0"
+    },
+    "index.docker.io/codeclimate/codeclimate-duplication:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/codeclimate-duplication-current",
+        "sha": "sha256:864b99c47545e2a1320a28bd2e655ec9bea68fb09856597a00548297ab116b51",
+        "tag": "24.82.236"
+    },
+    "index.docker.io/curlimages/curl:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/curlimages-curl-current",
+        "sha": "sha256:d7243bc5e1bd461cf93ba27572658d3a88cb8c76eb74c574427eb128461e6d65",
+        "tag": "24.84.297"
+    },
+    "index.docker.io/cypress/browsers:node18.12.0-chrome106-ff106": {
+        "notes": "this image is specified for *-mf team",
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/cypress-browsers-node-chrome-mf",
+        "sha": "sha256:61a10f6e554253914eb26e7c630b6ca548d5e2aacbb85cd9778c38b2493ee3a1",
+        "tag": "24.82.235"
+    },
+    "index.docker.io/cytopia/yamllint:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/yamllint",
+        "sha": "sha256:65c83e66789b0fb03f91f30a5897768e38a46a08d08c1759c6845d6a45331c75",
+        "tag": "1.26.3"
+    },
+    "index.docker.io/docker:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/docker-current",
+        "sha": "sha256:cc8f44c91bc36cf3480938ec1da459cd28ecc1875315f82ec3ab7d65a606dda1",
+        "tag": "24.84.3003"
+    },
+    "index.docker.io/golang:.*": [
+        {
+            "notes": "It's recommended to use golang-alpine unless you have debian dependency for underlying platform",
+            "registry": "artifactory-rd.netskope.io",
+            "repository": "org-base-release-docker/ns-builder/golang-alpine-current",
+            "sha": "sha256:45d75cd66550c6ebdc8603860e216bed8ca60d28f54c7735003c7f98f362d574",
+            "tag": "24.84.208"
+        },
+        {
+            "notes": "It's recommended to use alpine-dev-tools-current for manifest upload. ",
+            "registry": "artifactory-rd.netskope.io",
+            "repository": "org-base-release-docker/ns-builder/alpine-devtools-current",
+            "sha": "sha256:a46bf8f47605fa7d89bc284c64b462c6df0b6aec4f6a7c07e4f2c4a502ef6359",
+            "tag": "24.84.290"
+        }
+    ],
+    "index.docker.io/golangci/golangci-lint:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/golangci-lint-current",
+        "sha": "sha256:f2e5ea5e756a3e43b5ae90fcfbf3e6025ea0d4d9594c0c653e22a4a0433852b1",
+        "tag": "24.83.262"
+    },
+    "index.docker.io/gradle:(.*)-alpine": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/gradle-alpine-current",
+        "sha": "sha256:d8934b33c387b82520fdb11685eb9fa1b121fc35b3c920ae6a10c1e038467ac2",
+        "tag": "24.82.236"
+    },
+    "index.docker.io/hashicorp/terraform:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/terraform",
+        "sha": "sha256:3da18e37498014338c73cba3949792030fc2aa4c679aaadb9ea38f7a60fc7915",
+        "tag": "1.8.2"
+    },
+    "index.docker.io/makii42/untouched:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/untouched-current",
+        "sha": "sha256:7a5bce9a8d71b0906a20fa1dd1fd17faa9b76f9f0f6f323862fff2b3a939243b",
+        "tag": "24.82.235"
+    },
+    "index.docker.io/mikefarah/yq:4.40.5": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/yq",
+        "sha": "sha256:9cb9492ba78de24ae8190541dc9903d43b9bfd740b009c8649e1932a0e462c65",
+        "tag": "4.43.1"
+    },
+    "index.docker.io/mongo:.*": {
+        "notes": "mongo is mutating so we are using netskope version. You can check the labels for exact version of mongo.",
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/mongo-current",
+        "sha": "sha256:1aef36546854957a453d5a363cada820567299120521fed63891b77869b6d0a0",
+        "tag": "24.84.3017"
+    },
+    "index.docker.io/node:(.*)-alpine": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/node-alpine",
+        "sha": "sha256:ac80ee55f600c650dfda570df48fd4767792e251392aa1f8c6e5f4945352c3b1",
+        "tag": "24.84.3013"
+    },
+    "index.docker.io/openjdk:8-jre-alpine": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/openjdk-8-jre-alpine",
+        "sha": "sha256:72e91dbc1506c2b7c32bc7ac7373ed49ae7d115f4c445ba08044e3c65e64fbf7",
+        "tag": "8-jre-alpine"
+    },
+    "index.docker.io/pipelinecomponents/yamllint:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/pipelinecomponents-yamllint-current",
+        "sha": "sha256:398bca084cdc07bf62f50f9eb2781b8d67c243fde6c25e819e224cf93357905c",
+        "tag": "24.84.298"
+    },
+    "index.docker.io/plugins/docker:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/plugins-docker-current",
+        "sha": "sha256:a17f3dedc6053b2ace91865c4a05f880800b8b1452e50984370019b581814fff",
+        "tag": "24.83.209"
+    },
+    "index.docker.io/plugins/git:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/git-alpine-current",
+        "sha": "sha256:c7b7b922defa00476f0bb4c776961325d9fe4353d73f3b574ff231f59220e7c0",
+        "tag": "24.84.290"
+    },
+    "index.docker.io/prom/prometheus:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/prom-prometheus-current",
+        "sha": "sha256:9cee9e205e9654ad9c5db0a9a73c630cf82a3548394a32cbdfa1f4b1fdc7657e",
+        "tag": "24.84.235"
+    },
+    "index.docker.io/python:3.8-slim": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/python-3-8-slim-current",
+        "sha": "sha256:e138ea98abbe909fb24317450d0a5dada7d87f095b0df0cdc26b2a890a333509",
+        "tag": "24.84.298"
+    },
+    "index.docker.io/python:3\\.10(\\.[0-9]+)?-alpine.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/python-3-10-alpine",
+        "sha": "sha256:e1e8b06f242302cdb3503400ed222cea91433c09363b1a158627b7db8f3b103b",
+        "tag": "24.83.249"
+    },
+    "index.docker.io/redis:7.2.3": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/redis",
+        "sha": "sha256:10f996e0e4970b9468c7b0cf07e24ca1054019e614482aa069653e711c19ae69",
+        "tag": "7.2.4"
+    },
+    "index.docker.io/sonarsource/sonar-scanner-cli:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/sonarsource-sonar-scanner-cli-current",
+        "sha": "sha256:ae4f615c2b234bbf02afabd08d12c5b72640380f408929709e24580b139371e9",
+        "tag": "24.84.297"
+    },
+    "index.docker.io/summerwind/actions-runner-dind:v(\\d+).(\\d+).(\\d+)-ubuntu-20.04": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-builder/actions-runner-dind-2004-current",
+        "sha": "sha256:31433fbb61ed912076ac7ad948298204e7c5bea05ff3beed1b2c1d7efe9616d5",
+        "tag": "24.84.298"
+    },
+    "index.docker.io/ubuntu:16.04": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/vanilla-ubuntu-1604",
+        "sha": "sha256:180dde1b8e263a2c2fd2d84585533448d1968f5ec9429a27807b18e97344a575",
+        "tag": "24.82.235"
+    },
+    "index.docker.io/ubuntu:20.04": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/vanilla-ubuntu-2004",
+        "sha": "sha256:39d9c629aef19501219d8bea24ca86c8a7892bd9a01839fcc969f0ca9f0ccb66",
+        "tag": "24.84.3002"
+    },
+    "index.docker.io/ubuntu:22.04": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-ep/vanilla-ubuntu-2204",
+        "sha": "sha256:1f0c83cb6bfc1eec3cdb6b30d13046bdc3dbbd37efe982ea9cb3967fe81fc042",
+        "tag": "24.84.3002"
+    },
+    "index.docker.io/yugabytedb/yugabyte-client:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/yugabyte-client-current",
+        "sha": "sha256:cb8a80b4cc64c36cb7584fa5c38516e07d63b4a5282d50324c39e8bf09ccce26",
+        "tag": "24.84.3017"
+    },
+    "index.docker.io/yugabytedb/yugabyte:.*": {
+        "notes": null,
+        "registry": "artifactory-rd.netskope.io",
+        "repository": "org-base-release-docker/ns-dataprocessor/yugabyte-current",
+        "sha": "sha256:2202c45dfcf2f32b06f7f7f63dac965b42297caccc6fc79b7a778bbb8ae6a36b",
+        "tag": "24.84.3017"
+    }
+}


### PR DESCRIPTION
Why this change was made -
With these changes we will be able to identify and mark images as deprecated/non deprecated in docker registry UI. For details - [Link](https://netskope.atlassian.net/browse/EP-40356)

What is the change -
We have added json file which will contain replacement records. 
We have added conditional statements to checkImage method to check whether to mark image as deprecated or not.


Testing -
Did test this locally for both (deprecated and non deprecated cases) 

PFA
<img width="1512" alt="Screenshot 2024-05-08 at 5 55 58 PM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/a67cbe2e-fac1-49c2-9764-61b4a7a98f71">
<img width="990" alt="Screenshot 2024-05-08 at 5 56 53 PM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/5d5d112f-137e-478f-a208-eda8b1d58775">
