### PR TITLE
EP-43621: Code to add deprecated icon inside image details

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "rollup-plugin-riot": "^6.0.0",
     "rollup-plugin-scss": "^4.0.0",
     "rollup-plugin-serve": "^2.0.2"
+  },
+  "dependencies": {
+    "require": "^2.4.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,8 +43,5 @@
     "rollup-plugin-riot": "^6.0.0",
     "rollup-plugin-scss": "^4.0.0",
     "rollup-plugin-serve": "^2.0.2"
-  },
-  "dependencies": {
-    "require": "^2.4.20"
   }
 }

--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -81,8 +81,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import { matchSearch } from '../search-bar.riot';
     import * as data from './renovate-replacements-v2.json';
 
-    let keys = new Set();
-    export default {      
+    const cache = {};
+
+    export default {
       onBeforeMount(props, state) {
         if (props.item.images && props.item.images.length === 1) {
           state.image = props.item.images[0];
@@ -99,7 +100,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       onMounted(props, state) {
-        this.fetchData();
+        cache["renovate-replacements-data"] = this.fetchData();
         const materialCard = this.$('material-card');
         if (materialCard) {
           materialCard.style['z-index'] = props.zIndex;
@@ -127,12 +128,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       fetchData() {
+        const keys = [];
         for (const key in data.default) {
           if (key.includes("ns-ep") || key.includes("ns-builder")) {
-            keys.add(key);
+            keys.push(key);
           }
         }
         console.log(keys);
+        return keys;
       },
       checkImage(image) {
         console.log("checking image :- ", image);
@@ -141,8 +144,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             return true;
           }
         }
-        for (const key of keys) {
-          if (key.includes(image)) {
+        for (const idx in cache["renovate-replacements-data"]) {
+          console.log(cache["renovate-replacements-data"][idx]);
+          if (cache["renovate-replacements-data"][idx].includes(image)) {
             return true;
           }
         }
@@ -173,6 +177,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       matchSearch,
       router,
     };
+    export { cache }; 
   </script>
   <!-- End of tag -->
 </catalog-element>

--- a/src/components/tag-list/tag-list.riot
+++ b/src/components/tag-list/tag-list.riot
@@ -14,6 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
+
 <tag-list>
   <material-card class="header">
     <div class="material-card-title-action">
@@ -28,7 +29,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <i class="material-icons">arrow_back</i>
       </material-button>
       <h2>
-        Tags of { props.image }
+        Tags of { props.image } <span if="{ checkImage(props.image) }" class="github-label label-red">deprecated</span>
         <div class="source-hint">Sourced from { state.registryName + '/' + props.image }</div>
         <div class="item-count">{ state.tags.length } tags</div>
       </h2>
@@ -67,7 +68,24 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     pages="{ getPageLabels(state.page, getNumPages(state.tags, props.tagsPerPage)) }"
     onPageUpdate="{onPageUpdate}"
   ></pagination>
-
+  <style>
+  .github-label {
+  display: inline-block;
+  padding: 4px 8px;
+  margin-left: 20px;
+  font-size: 12px;
+  font-weight: bold;
+  border-radius: 4px;
+  }
+  .label-red {
+  color: #fff;
+  background-color: #d73a49; /* Red color used by GitHub */
+  }
+  .label-green {
+  color: #fff;
+  background-color: #28a745; /* Green color used by GitHub */
+  }
+  </style>
   <script>
     import { Http } from '../../scripts/http';
     import { DockerImage } from '../../scripts/docker-image';
@@ -76,6 +94,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import TagTable from './tag-table.riot';
     import router from '../../scripts/router';
     import { getTagComparator, taglistOrderParser } from '../../scripts/taglist-order';
+    import { cache } from '../catalog/catalog-element.riot';
 
     export default {
       components: {
@@ -151,7 +170,21 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         oReq.send();
         state.asc = true;
       },
-
+      checkImage(image) {
+        console.log("checking image :- ", image);
+        if (image) {
+          if (image.includes("-recent")){
+            return true;
+          }
+        }
+        console.log(cache);
+        for (const idx in cache["renovate-replacements-data"]) {
+          if (cache["renovate-replacements-data"][idx].includes(image)) {
+            return true;
+          }
+        }
+        return false;
+      },
       onPageUpdate(idx) {
         const labels = getPageLabels(this.state.page, getNumPages(this.state.tags, this.props.tagsPerPage));
         const page = labels[idx].page;


### PR DESCRIPTION
Why this change was made -
With these changes we will be able to identify and mark images as deprecated/non deprecated in docker registry UI inside Image details page. We've enabled a mechanism where deprecated records will be cached and reused in subsequent Image details page.

For details - [Link](https://netskope.atlassian.net/browse/EP-43621)

What is the change -
Had to make changes in code submitted by [PR](https://github.com/netSkope/docker-registry-ui/pull/10) to cache the json data for further consumption.
We have added logic to checkImage method to check whether image is deprecated or not.

Testing -
Did test this locally for both (deprecated and non deprecated cases) 

