### PR TITLE
EP-43621: Code to show location info for deprecated images

### DIFF
--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -32,7 +32,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <material-waves if="{ state.images }" center="true" color="#ddd"></material-waves>
       <span>
         <i class="material-icons">send</i>
-        { state.image || state.repo } <span if="{ checkImage(state.image) }" class="github-label label-red">deprecated</span>
+        { state.image || state.repo } <span if="{ checkImage(state.image) }" class="github-label label-red">Deprecated</span>
         <div if="{state.images}" class="item-count right">
           { state.nImages } images
           <i class="material-icons animated {state.expanded ? 'expanded' : ''}">expand_more</i>
@@ -128,25 +128,25 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       fetchData() {
-        const keys = [];
+        const keys = {};
         for (const key in data.default) {
           if (key.includes("ns-ep") || key.includes("ns-builder")) {
-            keys.push(key);
+            keys[key] = data.default[key];
           }
         }
         console.log(keys);
         return keys;
       },
       checkImage(image) {
-        console.log("checking image :- ", image);
+        console.log("Checking image :- ", image);
+        console.log("Cached data :- ", cache["renovate-replacements-data"]);
         if (image) {
           if (image.includes("-recent")){
             return true;
           }
         }
-        for (const idx in cache["renovate-replacements-data"]) {
-          console.log(cache["renovate-replacements-data"][idx]);
-          if (cache["renovate-replacements-data"][idx].includes(image)) {
+        for (var key in cache["renovate-replacements-data"]) {
+          if (key.includes(image)) {
             return true;
           }
         }

--- a/src/components/tag-list/tag-list.riot
+++ b/src/components/tag-list/tag-list.riot
@@ -29,7 +29,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <i class="material-icons">arrow_back</i>
       </material-button>
       <h2>
-        Tags of { props.image } <span if="{ checkImage(props.image) }" class="github-label label-red">deprecated</span>
+        Tags of { props.image } <span if="{ checkImage(props.image) }" class="github-label label-red">Deprecated</span>
+        <div class="deprecated-loc-hint" if="{ checkImage(props.image) }"><br>This stream of images moved to - <span>{ getImageLocation(props.image) }</span></div>
+        
         <div class="source-hint">Sourced from { state.registryName + '/' + props.image }</div>
         <div class="item-count">{ state.tags.length } tags</div>
       </h2>
@@ -171,19 +173,29 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.asc = true;
       },
       checkImage(image) {
-        console.log("checking image :- ", image);
+        console.log("Checking image :- ", image);
+        console.log("Cached data :- ", cache["renovate-replacements-data"]);
         if (image) {
           if (image.includes("-recent")){
             return true;
           }
         }
-        console.log(cache);
-        for (const idx in cache["renovate-replacements-data"]) {
-          if (cache["renovate-replacements-data"][idx].includes(image)) {
+        for (var key in cache["renovate-replacements-data"]) {
+          if (key.includes(image)) {
             return true;
           }
         }
         return false;
+      },
+      getImageLocation(image) {
+        console.log("Getting location of :- ", image);
+        console.log("Cached data :- ", cache["renovate-replacements-data"]);
+        for (var key in cache["renovate-replacements-data"]) {
+          if (key.includes(image)) {
+            return cache["renovate-replacements-data"][key];
+          }
+        }
+        return "";
       },
       onPageUpdate(idx) {
         const labels = getPageLabels(this.state.page, getNumPages(this.state.tags, this.props.tagsPerPage));

--- a/src/style.scss
+++ b/src/style.scss
@@ -133,6 +133,7 @@ h2 {
   overflow: hidden;
 }
 
+.material-card-title-action h2 .deprecated-loc-hint,
 .material-card-title-action h2 .source-hint,
 .material-card-title-action h2 .item-count {
   font-size: 0.7em;


### PR DESCRIPTION
Why this change was made -
With these changes we will be able to identify new location for deprecated images in docker registry UI inside Image details page. This needed fetching of values for individual keys with respective values from renovate-json file, so we had to make changes to the data structure.

For details - [Link](https://netskope.atlassian.net/browse/EP-43715)

What is the change -
This needed fetching of values for individual keys with respective values from renovate-json file, so we had to make changes to the data structure.
Added method to fetch new location info, based on already cached response (from renovate-json file)

Testing -
Did test this locally for both (deprecated and non deprecated cases) 

