### PR TITLE
EP-43715: Code changes to fix the bug where we showed object instead …

### DIFF
--- a/src/components/tag-list/tag-list.riot
+++ b/src/components/tag-list/tag-list.riot
@@ -192,7 +192,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         console.log("Cached data :- ", cache["renovate-replacements-data"]);
         for (var key in cache["renovate-replacements-data"]) {
           if (key.includes(image)) {
-            return cache["renovate-replacements-data"][key];
+            console.log(cache["renovate-replacements-data"][key]["repository"]);
+            return cache["renovate-replacements-data"][key]["repository"];
           }
         }
         return "";


### PR DESCRIPTION
Why this change was made -
With these changes we will be able to identify new location for deprecated images in docker registry UI inside Image details page. This needed fetching of values for individual keys with respective values from renovate-json file, so we had to make changes to the data structure.
This fixes a UI issue where we are not showing value of location, instead we are printing object. 

What is the change -
Correctly printing/returning the repository information of the object .

Testing -
Did test this locally for both (deprecated and non deprecated cases) 

PFA, images. 
<img width="1171" alt="Screenshot 2024-05-15 at 6 34 59 AM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/1baab579-c172-474e-af44-23d1f259bb19">
