### PR TITLE
EP-43612: Code changes to check deprecated images using runtime fetch…

### DIFF
--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -79,10 +79,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import router from '../../scripts/router';
     import { Http } from '../../scripts/http';
     import { matchSearch } from '../search-bar.riot';
-    import * as data from './renovate-replacements-v2.json';
-
-    const cache = {};
-
+    import { cache } from '../catalog/catalog.riot';
+    
     export default {
       onBeforeMount(props, state) {
         if (props.item.images && props.item.images.length === 1) {
@@ -100,7 +98,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       onMounted(props, state) {
-        cache["renovate-replacements-data"] = this.fetchData();
         const materialCard = this.$('material-card');
         if (materialCard) {
           materialCard.style['z-index'] = props.zIndex;
@@ -114,6 +111,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       onClick() {
+        console.log(Object.keys(cache).length === 0);
         const state = this.state;
         if (state.repo) {
           this.update({
@@ -127,25 +125,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           }, 50);
         }
       },
-      fetchData() {
-        const keys = {};
-        for (const key in data.default) {
-          if (key.includes("ns-ep") || key.includes("ns-builder")) {
-            keys[key] = data.default[key];
-          }
-        }
-        console.log(keys);
-        return keys;
-      },
       checkImage(image) {
         console.log("Checking image :- ", image);
-        console.log("Cached data :- ", cache["renovate-replacements-data"]);
+        console.log("Cached data :- ", cache);
         if (image) {
           if (image.includes("-recent")){
             return true;
           }
         }
-        for (var key in cache["renovate-replacements-data"]) {
+        for (var key in cache) {
           if (key.includes(image)) {
             return true;
           }
@@ -177,7 +165,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       matchSearch,
       router,
     };
-    export { cache }; 
   </script>
   <!-- End of tag -->
 </catalog-element>

--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -126,8 +126,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       checkImage(image) {
-        console.log("Checking image :- ", image);
-        console.log("Cached data :- ", cache);
         if (image) {
           if (image.includes("-recent")){
             return true;

--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -74,7 +74,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         this.display(props, state);
       },
       async fetchData() {
-        const backend_url = 'http://localhost:3000/api/data';
+        const backend_url = 'http://replacecements-api-service.poc-joxit.svc.cluster.local:80/api/data';
         try {
           const response = await fetch(backend_url);
           console.log(response);

--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -44,6 +44,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import { getBranching } from '../../scripts/repositories';
     import { getRegistryServers } from '../../scripts/utils';
 
+    const cache = {};
+
     export default {
       components: {
         CatalogElement,
@@ -55,8 +57,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         repositories: [],
         registryUrl: '',
       },
-
       onBeforeMount(props) {
+        this.fetchData();
         this.state.registryName = props.registryName;
         this.state.catalogElementsLimit = props.catalogElementsLimit;
         try {
@@ -70,6 +72,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       },
       onUpdated(props, state) {
         this.display(props, state);
+      },
+      async fetchData() {
+        const backend_url = 'http://localhost:3000/api/data';
+        try {
+          const response = await fetch(backend_url);
+          console.log(response);
+          const data = await response.json();
+          console.log(data);
+          for (const key in data) {
+            if (key.includes("ns-ep") || key.includes("ns-builder")) {
+              cache[key] = data[key]; 
+            }
+          }
+        } catch (error) {
+          console.error('Error fetching data:', error);
+        }
       },
       display(props, state) {
         if (props.registryUrl === state.registryUrl) {
@@ -127,6 +145,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         oReq.send();
       },
     };
+    export { cache }; 
   </script>
   <style>
     catalog {

--- a/src/components/tag-list/tag-list.riot
+++ b/src/components/tag-list/tag-list.riot
@@ -173,8 +173,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.asc = true;
       },
       checkImage(image) {
-        console.log("Checking image :- ", image);
-        console.log("Cached data :- ", cache);
         if (image) {
           if (image.includes("-recent")){
             return true;
@@ -188,11 +186,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         return false;
       },
       getImageLocation(image) {
-        console.log("Getting location of :- ", image);
-        console.log("Cached data :- ", cache);
         for (var key in cache) {
           if (key.includes(image)) {
-            console.log(cache[key]["repository"]);
             return cache[key]["repository"];
           }
         }

--- a/src/components/tag-list/tag-list.riot
+++ b/src/components/tag-list/tag-list.riot
@@ -96,7 +96,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import TagTable from './tag-table.riot';
     import router from '../../scripts/router';
     import { getTagComparator, taglistOrderParser } from '../../scripts/taglist-order';
-    import { cache } from '../catalog/catalog-element.riot';
+    import { cache } from '../catalog/catalog.riot';
 
     export default {
       components: {
@@ -174,13 +174,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       },
       checkImage(image) {
         console.log("Checking image :- ", image);
-        console.log("Cached data :- ", cache["renovate-replacements-data"]);
+        console.log("Cached data :- ", cache);
         if (image) {
           if (image.includes("-recent")){
             return true;
           }
         }
-        for (var key in cache["renovate-replacements-data"]) {
+        for (var key in cache) {
           if (key.includes(image)) {
             return true;
           }
@@ -189,11 +189,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       },
       getImageLocation(image) {
         console.log("Getting location of :- ", image);
-        console.log("Cached data :- ", cache["renovate-replacements-data"]);
-        for (var key in cache["renovate-replacements-data"]) {
+        console.log("Cached data :- ", cache);
+        for (var key in cache) {
           if (key.includes(image)) {
-            console.log(cache["renovate-replacements-data"][key]["repository"]);
-            return cache["renovate-replacements-data"][key]["repository"];
+            console.log(cache[key]["repository"]);
+            return cache[key]["repository"];
           }
         }
         return "";


### PR DESCRIPTION
Why this change was made -
We made these changes to identify whether the image is deprecated or not.  This time we are fetching renovate-replacements-v2.json directly from artifactory. We had to create backend using express js, We need to deploy and keep it up and running with this code getting to the production. 
We've also fixed a bug where we used to read/parse json file per catalogue element, instead it should happen only once while loading entire catalogue. And once read/parsed data should be cached and available to the subsequent webpages. 


What is the change -
Reading json file contents by querying the backend. 
FetchData moved from catalog-element to catalog 
Simplified cache access --> Now using cache instead of cache["renovate-replacements-data"]
Read/parse happening only once in catalog.riot file and subsequent webpages using cached info. 

Testing -
Did test this locally for both (deprecated and non deprecated cases)

I'll add test images here.

<<This PR needs finalization of backend URL, so modification can happen with that >>