### PR TITLE
EP-44755: Code changes to add home hyperlink to all webpages

### DIFF
--- a/src/components/docker-registry-ui.riot
+++ b/src/components/docker-registry-ui.riot
@@ -19,7 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <material-navbar>
       <span id="custom_logo" class='custom_logo' >
       </span>
-        <span>Docker Registry UI</span>
+        <a href="/" id="homeLink"><span>Docker Registry UI</span></a>
         <version-notification version="{ latest }" on-notify="{ notifySnackbar }"></version-notification>
       <div class="menu">
         <search-bar on-search="{ onSearch }"></search-bar>
@@ -273,6 +273,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     };
   </script>
   <style>
+    a {
+        text-decoration: none;
+    }
     :host {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
Why this change was made -
These changes will provide home redirection on all webpages of netskope docker registry UI . For details - [Link](https://netskope.atlassian.net/browse/EP-44755)

What is the change -
html redirections and css modifications

Testing -
Tested locally, No regressions found. DOcker registry UI text is clickable on all webpages. 

PFA - 
<img width="1728" alt="Screenshot 2024-05-30 at 10 36 33 AM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/ef5d4a49-e633-492b-987d-3ef6914bd57d">
