### PR TITLE
EP-44998: Code changes to add checkbox functionality to exclude number of deprecated images from total number of images

### DIFF
--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -51,7 +51,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     const cache = {};
     let repo = [];
-    
+
     export default {
       components: {
         CatalogElement,
@@ -67,7 +67,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       },
       onBeforeMount(props) {
         this.fetchData();
-        
         this.state.registryName = props.registryName;
         this.state.catalogElementsLimit = props.catalogElementsLimit;
         try {
@@ -75,7 +74,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         } catch (e) {
           props.onNotify(e);
         }
-        
       },
       onMounted(props, state) {
         this.display(props, state);
@@ -84,8 +82,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             console.log("Length of array:", repo.length); // This should print the correct length
             let deprecatedImagesCount = 0
             for (let i = 0; i < repo.length; i++){
-              console.log(repo[i]);
-
               if (repo[i]) {
                 if (repo[i].includes("-recent")){
                   deprecatedImagesCount = deprecatedImagesCount + 1;
@@ -96,27 +92,21 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                   deprecatedImagesCount = deprecatedImagesCount + 1;
                 }
               }
-
             }
-            console.log(deprecatedImagesCount);
             this.state.numberOfDeprecatedImages = deprecatedImagesCount;
-            console.log(this.state.numberOfDeprecatedImages);
+            console.log("Number of deprecated images: ", this.state.numberOfDeprecatedImages);
             this.update();
 
         }).catch(error => {
             console.error("Error:", error);
         });
         var storedState = localStorage.getItem('checkboxChecked');
-        console.log("storedState");
-        console.log(storedState);
-        console.log("storedState");
-        
+        console.log("Stored State: ", storedState);        
         if (storedState !== null) {
           this.state.checkboxChecked = storedState === 'true';
           // Update checkbox's checked attribute based on stored state
           document.getElementById('reloadCheckbox').checked = this.state.checkboxChecked;
-        }
-        
+        }        
       },
       onUpdated(props, state) {
         this.display(props, state);
@@ -177,8 +167,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             repositories.sort();
             
             nImages = repositories.length;
-            console.log(repositories.length)
-
             if (typeof state.branching === 'function') {
               repositories = state.branching(repositories);
             }
@@ -201,13 +189,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         oReq.addEventListener('error', function () {
           self.props.onNotify(this.getErrorMessage(), true);
         });
-        
         repo = repositories;
-
-        console.log("cache");
-        console.log(cache);
-        console.log("cache");
-        
         oReq.addEventListener('loadend', function () {
           self.update({
             repositories,
@@ -218,7 +200,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
         oReq.open('GET', catalogUrl);
         oReq.send();
-        console.log(this.state.numberOfDeprecatedImages);
       },
       
     };

--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -20,7 +20,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <h2>
         Repositories of { state.registryName }
         <div class="item-count">
-          { this.state.checkboxChecked ? `${state.nImages - this.state.numberOfDeprecatedImages} images in ${state.nRepositories} repositories (Checkbox is checked)` : `${state.nImages} images in ${state.nRepositories} repositories (Checkbox is unchecked)` }
+          { this.state.checkboxChecked ? `${state.nImages - this.state.numberOfDeprecatedImages} images in ${state.nRepositories} repositories` : `${state.nImages} images in ${state.nRepositories} repositories` }
           <br>
           <label for="reloadCheckbox">Exclude deprecated images</label>
           <input type="checkbox" id="reloadCheckbox" onclick={ () => this.onClick() } checked={ this.state.checkboxChecked }>

--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -96,7 +96,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             this.state.numberOfDeprecatedImages = deprecatedImagesCount;
             console.log("Number of deprecated images: ", this.state.numberOfDeprecatedImages);
             this.update();
-
         }).catch(error => {
             console.error("Error:", error);
         });
@@ -136,9 +135,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
       },
       onClick() {
-        console.log("we are in here onClick");
         this.state.checkboxChecked = document.getElementById('reloadCheckbox');
-        console.log(this.state.checkboxChecked.checked);
         localStorage.setItem('checkboxChecked', this.state.checkboxChecked.checked);
         window.location.reload();
       },
@@ -157,7 +154,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
         oReq.addEventListener('load', function () {
           if (this.status === 200) {
-              
             let repositories_1 = JSON.parse(this.responseText).repositories || [];
             for (let i = 0; i < repositories_1.length; i++){
               if (!repositories_1[i].includes("unlabeled") && !repositories_1[i].includes("action-push")){
@@ -165,7 +161,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               }
             }
             repositories.sort();
-            
             nImages = repositories.length;
             if (typeof state.branching === 'function') {
               repositories = state.branching(repositories);
@@ -184,7 +179,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           } else {
             self.props.onNotify(this.responseText);
           }
-
         });
         oReq.addEventListener('error', function () {
           self.props.onNotify(this.getErrorMessage(), true);
@@ -201,7 +195,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         oReq.open('GET', catalogUrl);
         oReq.send();
       },
-      
     };
     export { cache }; 
   </script>

--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -19,7 +19,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <div class="material-card-title-action">
       <h2>
         Repositories of { state.registryName }
-        <div class="item-count">{ state.nImages } images in { state.nRepositories } repositories</div>
+        <div class="item-count">
+          { this.state.checkboxChecked ? `${state.nImages - this.state.numberOfDeprecatedImages} images in ${state.nRepositories} repositories (Checkbox is checked)` : `${state.nImages} images in ${state.nRepositories} repositories (Checkbox is unchecked)` }
+          <br>
+          <label for="reloadCheckbox">Exclude deprecated images</label>
+          <input type="checkbox" id="reloadCheckbox" onclick={ () => this.onClick() } checked={ this.state.checkboxChecked }>
+        </div>
       </h2>
     </div>
   </material-card>
@@ -45,7 +50,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import { getRegistryServers } from '../../scripts/utils';
 
     const cache = {};
-
+    let repo = [];
+    
     export default {
       components: {
         CatalogElement,
@@ -56,9 +62,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         loadend: false,
         repositories: [],
         registryUrl: '',
+        checkboxChecked: false,
+        numberOfDeprecatedImages: 0,
       },
       onBeforeMount(props) {
         this.fetchData();
+        
         this.state.registryName = props.registryName;
         this.state.catalogElementsLimit = props.catalogElementsLimit;
         try {
@@ -66,9 +75,48 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         } catch (e) {
           props.onNotify(e);
         }
+        
       },
       onMounted(props, state) {
         this.display(props, state);
+        this.fetchRepositories(repo).then(repo => {
+            console.log("Populated array:", repo);
+            console.log("Length of array:", repo.length); // This should print the correct length
+            let deprecatedImagesCount = 0
+            for (let i = 0; i < repo.length; i++){
+              console.log(repo[i]);
+
+              if (repo[i]) {
+                if (repo[i].includes("-recent")){
+                  deprecatedImagesCount = deprecatedImagesCount + 1;
+                }
+              }
+              for (var key in cache) {
+                if (key.includes(repo[i])) {
+                  deprecatedImagesCount = deprecatedImagesCount + 1;
+                }
+              }
+
+            }
+            console.log(deprecatedImagesCount);
+            this.state.numberOfDeprecatedImages = deprecatedImagesCount;
+            console.log(this.state.numberOfDeprecatedImages);
+            this.update();
+
+        }).catch(error => {
+            console.error("Error:", error);
+        });
+        var storedState = localStorage.getItem('checkboxChecked');
+        console.log("storedState");
+        console.log(storedState);
+        console.log("storedState");
+        
+        if (storedState !== null) {
+          this.state.checkboxChecked = storedState === 'true';
+          // Update checkbox's checked attribute based on stored state
+          document.getElementById('reloadCheckbox').checked = this.state.checkboxChecked;
+        }
+        
       },
       onUpdated(props, state) {
         this.display(props, state);
@@ -89,6 +137,21 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           console.error('Error fetching data:', error);
         }
       },
+      fetchRepositories(repo) {
+        return new Promise((resolve, reject) => {
+            // Simulating an asynchronous operation (e.g., fetching data from an API)
+            setTimeout(() => {
+                resolve(repo); // Resolve the promise with the populated array
+            }, 1000); // Simulate a delay of 1 second
+        });
+      },
+      onClick() {
+        console.log("we are in here onClick");
+        this.state.checkboxChecked = document.getElementById('reloadCheckbox');
+        console.log(this.state.checkboxChecked.checked);
+        localStorage.setItem('checkboxChecked', this.state.checkboxChecked.checked);
+        window.location.reload();
+      },
       display(props, state) {
         if (props.registryUrl === state.registryUrl) {
           return;
@@ -104,6 +167,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
         oReq.addEventListener('load', function () {
           if (this.status === 200) {
+              
             let repositories_1 = JSON.parse(this.responseText).repositories || [];
             for (let i = 0; i < repositories_1.length; i++){
               if (!repositories_1[i].includes("unlabeled") && !repositories_1[i].includes("action-push")){
@@ -111,7 +175,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               }
             }
             repositories.sort();
+            
             nImages = repositories.length;
+            console.log(repositories.length)
+
             if (typeof state.branching === 'function') {
               repositories = state.branching(repositories);
             }
@@ -129,10 +196,18 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           } else {
             self.props.onNotify(this.responseText);
           }
+
         });
         oReq.addEventListener('error', function () {
           self.props.onNotify(this.getErrorMessage(), true);
         });
+        
+        repo = repositories;
+
+        console.log("cache");
+        console.log(cache);
+        console.log("cache");
+        
         oReq.addEventListener('loadend', function () {
           self.update({
             repositories,
@@ -143,7 +218,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
         oReq.open('GET', catalogUrl);
         oReq.send();
+        console.log(this.state.numberOfDeprecatedImages);
       },
+      
     };
     export { cache }; 
   </script>


### PR DESCRIPTION
Why this change was made -
Currently docker registry UI have some deprecated images, we want those images to excluded when we count for the total number of images on the product home page. 
We also wanted to keep total number of images, so we had to provide user with an option to click the checkbox to exclude number of deprecated images from the total image number.

<Please Note> We get the number of deprecated images after we get the json file and do the processing to find out which out of those are deprecated ones. So its a bit time consuming, We cant stop page loading till that time, so we adopted the [eventual consistency](https://en.wikipedia.org/wiki/Eventual_consistency)  for data loading on UI. RIOT supports it. 
   
For details - [Link](https://netskope.atlassian.net/browse/EP-44998)

What is the change -
We have modified catalog.riot code, 
html changes to add the checkbox and respective selection/ selection retention and post selection actions 
javascript changes to perform the actions/ calculations after selection/de-selection of the checkbox

Testing -
PFA, images of local testing
<img width="715" alt="Screenshot 2024-06-14 at 4 19 39 PM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/4a0237e5-e706-4f15-852a-6472adc1f3bb">
<img width="658" alt="Screenshot 2024-06-14 at 4 19 50 PM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/87b85c05-35fe-4d97-805c-419a68df9569">
