### PR TITLE
EP-46493: Code changes to hide deprecated images when we click exclude deprecated images checkbox

### DIFF
--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -20,10 +20,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       <h2>
         Repositories of { state.registryName }
         <div class="item-count">
-          { this.state.checkboxChecked ? `${state.nImages - this.state.numberOfDeprecatedImages} images in ${state.nRepositories} repositories` : `${state.nImages} images in ${state.nRepositories} repositories` }
-          <br>
-          <label for="reloadCheckbox">Exclude deprecated images</label>
+          { this.state.checkboxChecked ? `${state.nImages - this.state.numberOfDeprecatedImages} Images in ${state.nRepositories} Repositories (` : `${state.nImages} Images in ${state.nRepositories} Repositories (` }
           <input type="checkbox" id="reloadCheckbox" onclick={ () => this.onClick() } checked={ this.state.checkboxChecked }>
+          <label for="reloadCheckbox">Exclude Deprecated )</label>
         </div>
       </h2>
     </div>

--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -51,6 +51,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
     const cache = {};
     let repo = [];
+    let excludeImages = false;
 
     export default {
       components: {
@@ -103,6 +104,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         console.log("Stored State: ", storedState);        
         if (storedState !== null) {
           this.state.checkboxChecked = storedState === 'true';
+          excludeImages = this.state.checkboxChecked;
           // Update checkbox's checked attribute based on stored state
           document.getElementById('reloadCheckbox').checked = this.state.checkboxChecked;
         }        
@@ -152,48 +154,77 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           onAuthentication: this.props.onAuthentication,
           withCredentials: props.isRegistrySecured,
         });
-        oReq.addEventListener('load', function () {
-          if (this.status === 200) {
-            let repositories_1 = JSON.parse(this.responseText).repositories || [];
-            for (let i = 0; i < repositories_1.length; i++){
-              if (!repositories_1[i].includes("unlabeled") && !repositories_1[i].includes("action-push")){
-                repositories.push(repositories_1[i])
+        this.fetchRepositories(cache).then(cache => {
+          console.log("Populated cache:", cache);
+          oReq.addEventListener('load', function () {
+            if (this.status === 200) {
+              let repositories_1 = JSON.parse(this.responseText).repositories || [];
+              if (excludeImages === true) {
+                for (let i = 0; i < repositories_1.length; i++){
+                    console.log(repositories_1[i]);
+                    if (!repositories_1[i].includes("unlabeled") && !repositories_1[i].includes("action-push")) {
+                      if (!repositories_1[i].includes("-recent")) {
+                        let tflg = false;
+                        for (var key in cache) {
+                          if (key.includes(repositories_1[i])) {
+                            tflg = true;
+                          }
+                        }
+                        if (tflg === false) {
+                          repositories.push(repositories_1[i]);
+                        }
+                      }
+                    }
+                  }
+                  console.log(excludeImages);
+                  console.log("repositories", repositories);
+              } else {
+                  for (let i = 0; i < repositories_1.length; i++){
+                    console.log(repositories_1[i]);
+                    if (!repositories_1[i].includes("unlabeled") && !repositories_1[i].includes("action-push")) {
+                      repositories.push(repositories_1[i]);
+                    }
+                  }
+                  console.log(excludeImages);
+                  console.log("repositories", repositories);
+                }
+              repositories.sort();
+              nImages = repositories.length;
+              if (typeof state.branching === 'function') {
+                repositories = state.branching(repositories);
               }
+            } else if (this.status === 404) {
+              self.props.onNotify({ code: 'CATALOG_NOT_FOUND', url: catalogUrl }, true);
+            } else if (this.status === 400) {
+              let response;
+              try {
+                response = JSON.parse(this.responseText);
+              } catch (e) {}
+              if (!response || !Array.isArray(response.errors)) {
+                return self.props.onNotify(this.responseText, true);
+              }
+              self.props.onNotify({ ...response, url: catalogUrl }, true);
+            } else {
+              self.props.onNotify(this.responseText);
             }
-            repositories.sort();
-            nImages = repositories.length;
-            if (typeof state.branching === 'function') {
-              repositories = state.branching(repositories);
-            }
-          } else if (this.status === 404) {
-            self.props.onNotify({ code: 'CATALOG_NOT_FOUND', url: catalogUrl }, true);
-          } else if (this.status === 400) {
-            let response;
-            try {
-              response = JSON.parse(this.responseText);
-            } catch (e) {}
-            if (!response || !Array.isArray(response.errors)) {
-              return self.props.onNotify(this.responseText, true);
-            }
-            self.props.onNotify({ ...response, url: catalogUrl }, true);
-          } else {
-            self.props.onNotify(this.responseText);
-          }
-        });
-        oReq.addEventListener('error', function () {
-          self.props.onNotify(this.getErrorMessage(), true);
-        });
-        repo = repositories;
-        oReq.addEventListener('loadend', function () {
-          self.update({
-            repositories,
-            nRepositories: repositories.length,
-            nImages,
-            loadend: true,
           });
+          oReq.addEventListener('error', function () {
+            self.props.onNotify(this.getErrorMessage(), true);
+          });
+          repo = repositories;
+          oReq.addEventListener('loadend', function () {
+            self.update({
+              repositories,
+              nRepositories: repositories.length,
+              nImages,
+              loadend: true,
+            });
+          });
+          oReq.open('GET', catalogUrl);
+          oReq.send();
+        }).catch(error => {
+            console.error("Error:", error);
         });
-        oReq.open('GET', catalogUrl);
-        oReq.send();
       },
     };
     export { cache }; 


### PR DESCRIPTION
Why this change was made -
Currently docker registry UI have some deprecated images, we want those images to excluded when we count for the total number of images on the product home page. 
When user clicks to exclude images individual image count (non-deprecated image count) should also be updated at the same time, user should not be able to see the set of deprecated images.
   
For details - [Link](https://netskope.atlassian.net/browse/EP-46493)

What is the change -
We have modified catalog.riot code, 
javascript changes to perform the actions/ calculations after selection/de-selection of the checkbox

Testing -
PFA, images of local testing

<img width="1512" alt="Screenshot 2024-07-02 at 11 11 40 AM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/e8f088a3-15cd-4a24-96ae-e8742f8c23f5">
<img width="1530" alt="Screenshot 2024-07-02 at 11 40 38 AM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/f5fd042e-1642-490b-a83c-a4d9d164fbf1">

<img width="1518" alt="Screenshot 2024-07-02 at 11 11 57 AM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/35d41126-1a55-42db-881b-db0e8105550d">
<img width="659" alt="Screenshot 2024-07-02 at 4 39 27 PM" src="https://github.com/netSkope/docker-registry-ui/assets/151713372/c894df08-85fe-48a2-af7c-3277e25c87e8">
