### PR TITLE
EP-47229: Code changes to add icons to both env and labels sections

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -74,7 +74,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   </material-card>
   
   <material-card each="{element in state.envelements}">
-    <h3>&nbsp;&nbsp;<i class="material-icons">notes</i> ENV </h3>
+    <h2>&nbsp;&nbsp;<i class="material-icons">notes</i>&nbsp; ENV </h2>
     <image-label
       each="{ entry in element }"
       if="{ entry.value && entry.value.length > 0}"
@@ -83,7 +83,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   </material-card>
 
   <material-card each="{element in state.labelelements}">
-   <h3>&nbsp;&nbsp;<i class="material-icons">label</i> Labels </h3> 
+   <h2>&nbsp;&nbsp;<i class="material-icons">label</i>&nbsp; Labels </h2> 
    <image-label
     each="{ entry in element }"
     if="{ entry.value && entry.value.length > 0}"

--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -74,7 +74,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   </material-card>
   
   <material-card each="{element in state.envelements}">
-    <h3>&nbsp;&nbsp;ENV </h3>
+    <h3>&nbsp;&nbsp;<i class="material-icons">notes</i> ENV </h3>
     <image-label
       each="{ entry in element }"
       if="{ entry.value && entry.value.length > 0}"
@@ -83,7 +83,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   </material-card>
 
   <material-card each="{element in state.labelelements}">
-   <h3>&nbsp;&nbsp;Labels </h3>
+   <h3>&nbsp;&nbsp;<i class="material-icons">label</i> Labels </h3> 
    <image-label
     each="{ entry in element }"
     if="{ entry.value && entry.value.length > 0}"


### PR DESCRIPTION
Why this change was made -
Currently in docker registry UI on tag history page we are missing icons for both ENV and labels section, we are trying to add those thru. this PR.

For details - [Link](https://netskope.atlassian.net/browse/EP-47229)

What is the change -
Minor HTML/js code changes

Testing -

PFA, the image of local testing. 
<img width="1455" alt="Screenshot 2024-07-26 at 10 16 43 AM" src="https://github.com/user-attachments/assets/a3c4aadb-2c1a-4928-afde-3a4642849c42">


Updates - 
Review suggestion - Fix vertical alignment mismatch between icon and the text. 