### PR TITLE
EP-48023: Code changes to fix broken labels view on tag history page

### DIFF
--- a/src/components/tag-history/image-label.riot
+++ b/src/components/tag-history/image-label.riot
@@ -35,7 +35,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.icon = getHistoryIcon(props.entry.key);
         state.name = props.entry.key;  
         try {
-            state.values = Object.entries(JSON.parse(props.entry.value));
+            state.values = Object.entries(JSON.parse(props.entry.value.replace(/^"|"$/g, '')));
             if (state.values.length==0){
               throw new Error();
             }
@@ -48,7 +48,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
                 })
         }
         catch(e){
-            state.value = String(props.entry.value) 
+            let result = String(props.entry.value);
+            state.value = result.replace(/^"|"$/g, '');
         }
         
       },


### PR DESCRIPTION
Why this change was made -
Currently in docker registry UI on tag history page we see some labels view is broken. PFA. 

<img width="1449" alt="Screenshot 2024-07-26 at 10 35 08 AM" src="https://github.com/user-attachments/assets/d1c02686-4152-47bf-b8a0-c2b79b188a09">

This was happening for ns-service/mtail-current. 

We've added more debug details here -  [Link](https://netskope.atlassian.net/browse/EP-48023)

What is the change -
js code changes to remove double quotes from beginning and end of the string value label.

Testing -

PFA, the image of local testing.

![Uploading Screenshot 2024-07-29 at 11.43.00 AM.png…]()
