### PR TITLE
EP-48257: added FAQ's page.

### DIFF
--- a/src/components/help.riot
+++ b/src/components/help.riot
@@ -8,7 +8,7 @@
     <material-card>
       <a href="https://netskope.atlassian.net/wiki/spaces/PE/pages/4610556807/Guidelines+for+creating+ep-pokeball+images" style="text-decoration: none; color: inherit;">
         <material-waves center="true" color="#ddd"></material-waves>
-        <div class="content"><b>For more details, where can I refer?</b></div><br>
+        <div class="content"><b>9.For more details, where can I refer?</b></div><br>
         <div class="content"><b>Ans:</b>&nbsp<span>FAQs</span></div>
       </a>
     </material-card>

--- a/src/components/help.riot
+++ b/src/components/help.riot
@@ -5,6 +5,13 @@
       <div class="content"><b>{item.question}</b></div><br>
       <div class="content"><b>Ans:</b>&nbsp<i>{item.answer}</i></div>
     </material-card>
+    <material-card>
+      <a href="https://netskope.atlassian.net/wiki/spaces/PE/pages/4610556807/Guidelines+for+creating+ep-pokeball+images" style="text-decoration: none; color: inherit;">
+        <material-waves center="true" color="#ddd"></material-waves>
+        <div class="content"><b>For more details, where can I refer?</b></div><br>
+        <div class="content"><b>Ans:</b>&nbsp<span>FAQs</span></div>
+      </a>
+    </material-card>
   </div>
   <script>
     export default {

--- a/src/components/help.riot
+++ b/src/components/help.riot
@@ -1,17 +1,18 @@
 <help>
   <div>
+    <material-card>
+      <a href="https://netskope.atlassian.net/wiki/spaces/PE/pages/4610556807/Guidelines+for+creating+ep-pokeball+images" style="text-decoration: none; color: inherit;">
+        <material-waves center="true" color="#ddd"></material-waves>
+        <div class="content"><b>0.For more exhaustive list of FAQS, where can I refer?</b></div><br>
+        <div class="content"><b>Ans:</b>&nbsp<span>WIKI PAGE</span></div>
+      </a>
+    </material-card>
     <material-card each={item in state.faqData}>
       <material-waves center="true" color="#ddd"></material-waves>
       <div class="content"><b>{item.question}</b></div><br>
       <div class="content"><b>Ans:</b>&nbsp<i>{item.answer}</i></div>
     </material-card>
-    <material-card>
-      <a href="https://netskope.atlassian.net/wiki/spaces/PE/pages/4610556807/Guidelines+for+creating+ep-pokeball+images" style="text-decoration: none; color: inherit;">
-        <material-waves center="true" color="#ddd"></material-waves>
-        <div class="content"><b>9.For more details, where can I refer?</b></div><br>
-        <div class="content"><b>Ans:</b>&nbsp<span>FAQs</span></div>
-      </a>
-    </material-card>
+    
   </div>
   <script>
     export default {


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2024-08-01 at 4 07 57 PM" src="https://github.com/user-attachments/assets/0a84f715-ca01-4df4-be81-62a2a5bc30e9">

FAQ's Routed to: https://netskope.atlassian.net/wiki/spaces/PE/pages/4610556807/Guidelines+for+creating+ep-pokeball+images