### PR TITLE
EP-48316: Code changes to download report of given image and present it on ui

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -50,6 +50,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     on-close="{ onDockerfileClose }"
     elements="{ state.elements }"
     labelelements = "{ state.labelelements }"
+    reportelements = "{ state.reportelements }"
     envelements = "{ state.envelements }"
   ></dockerfile>
 
@@ -91,6 +92,17 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
    ></image-label>
   </material-card>
 
+  <material-card each="{reportelements in state.reportelements}">
+    <h2>&nbsp;&nbsp;<i class="material-icons">notes</i>&nbsp; Vulnerability Report </h2>
+    <material-card each="{element in reportelements}">
+    <image-label
+      each="{ entry in element }"
+      if="{ entry.value && entry.value.length > 0}"
+      entry="{ entry }"
+    ></image-label>
+    </material-card>
+  </material-card>
+
   <script>
     import { DockerImage } from '../../scripts/docker-image';
     import { bytesToSize } from '../../scripts/utils';
@@ -107,6 +119,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       onBeforeMount(props, state) {
         state.elements = [];
         state.labelelements = [];
+        state.reportelements = [];
         state.envelements = [];
         state.image = new DockerImage(props.image, props.tag, {
           list: true,
@@ -127,6 +140,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         const { registryUrl, onNotify, useControlCacheHeader } = this.props;
         state.elements = [];
         state.labelelements = [];
+        state.reportelements = [];
         state.envelements = [];
         state.image.variants[idx] =
           state.image.variants[idx] ||
@@ -143,7 +157,23 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.image.variants[idx].fillInfo();;
         state.image.variants[idx].on('blobs', this.processBlobs);
       },
-      processBlobs(blobs) {
+
+      async fetchReport(family, image, tag) {
+        const queryParams = new URLSearchParams({ family, image, tag }).toString();
+        const backend_url = `https://ep-pokeball.netskope.io/api/report?${queryParams}`;
+        console.log(backend_url);
+        try {
+          const response = await fetch(backend_url);
+          const data = await response.json();
+          return data;
+
+        } catch (error) {
+          console.error('Error fetching data:', error);
+          return []
+        }
+      },
+      async processBlobs(blobs) {
+        let reportelements = [];
         const state = this.state;
         const { historyCustomLabels } = this.props;
         const labels = this.state.image.blobs.config.Labels;
@@ -167,18 +197,34 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           }
           return guiElements.sort(eltSort);
         }
+        const keySet = new Set(["VulnerabilityID", "PkgName", "InstalledVersion", "Severity"]);
         const elements = new Array(1);
         elements[0] = exec(getConfig(blobs, { historyCustomLabels }));
-        // blobs.history.forEach(function (elt, i) {
-        //   elements[blobs.history.length - i] = exec(elt);
-        // });
-
+        const reportData = await this.fetchReport(state.image.name.split("/")[0], state.image.name.split("/")[1], state.image.tag);
+        console.log("reportData", reportData);
+        if ('error' in reportData) {
+          console.log("Error in downloading report. Please check existence of the report in artifactory");
+        } else if (reportData[0].hasOwnProperty("Vulnerabilities")) {
+          for (const vulnerability of reportData[0]["Vulnerabilities"]) {
+            let tempArray = [];
+            for (const [key, value] of Object.entries(vulnerability)) {
+              let tempMap = {};
+              if (keySet.has(key)) {
+                tempMap["key"] = key;
+                tempMap["value"] = value;
+                tempArray.push(tempMap);
+              }
+            }
+            reportelements.push(tempArray);
+          }
+        }
         this.update({
           elements,
           loadend: true,
         });
         this.state.labelelements.push(labelelements);
         this.state.envelements.push(envelements);
+        this.state.reportelements.push(reportelements);
         this.update();
       },
 


### PR DESCRIPTION
EP-48316: Code changes to download report of given image and present it on ui

Why this change was made -
We have added a mechanism thru. which we trivy scan ep-pokeball images, we generate reports of the same and upload it to artifactory location. We have already created API to access scan report of a given image [Refer]([EP-48314](https://netskope.atlassian.net/browse/EP-48314)) 
This PR intends to invoke API and fetch + parse json report and presents in on UI. 
@ns-ggeorgiev  mentioned for this PR, we will present report data as is. Based on discussion with @ns-snandan  I've removed some (not needed) fields of a given vulnerability to make report more focussed and avoid unnecessary details.

For details - [Link](https://netskope.atlassian.net/browse/EP-48316)

What is the change -
We have modified tag-history.riot code,
Removing some legacy commented code. 

Testing -

PFA, local testing images for different cases - 

Happy path testing - 
<img width="1202" alt="Screenshot 2024-08-06 at 6 32 15 PM" src="https://github.com/user-attachments/assets/900d4142-0525-4489-9eb0-a4eb14b7d15e">



Cases where report is not present in artifactory - 
<img width="1315" alt="Screenshot 2024-08-06 at 6 20 31 PM" src="https://github.com/user-attachments/assets/2355a967-7fff-4942-a492-be6eccadf952">


Cases where we fail to download the report - 
<img width="1315" alt="Screenshot 2024-08-06 at 6 20 31 PM" src="https://github.com/user-attachments/assets/2355a967-7fff-4942-a492-be6eccadf952">

Cases where we get the report but the image is vulnerability free - 
<img width="1315" alt="Screenshot 2024-08-06 at 6 20 31 PM" src="https://github.com/user-attachments/assets/2355a967-7fff-4942-a492-be6eccadf952">




[EP-48314]: https://netskope.atlassian.net/browse/EP-48314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ