### PR TITLE
EP-48885: Code changes to fix broken tag history vulnerability report

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -204,8 +204,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         console.log("reportData", reportData);
         if ('error' in reportData) {
           console.log("Error in downloading report. Please check existence of the report in artifactory");
-        } else if (reportData[0].hasOwnProperty("Vulnerabilities")) {
-          for (const vulnerability of reportData[0]["Vulnerabilities"]) {
+        } else if (reportData.Results[0].hasOwnProperty("Vulnerabilities")) {
+          for (const vulnerability of reportData.Results[0]["Vulnerabilities"]) {
             let tempArray = [];
             for (const [key, value] of Object.entries(vulnerability)) {
               let tempMap = {};


### PR DESCRIPTION
Why this change was made - 
There are few changes that we did recently, it caused change in structure for vulnerability report. 
We need to change our ways we used to fetch list of vulnerabilities from the report. 

What is the change - 
change in tag-history.riot file 

Testing - 
<img width="894" alt="Screenshot 2024-08-09 at 5 18 23 PM" src="https://github.com/user-attachments/assets/99bcc488-574e-481c-abb7-f0b6feeef89e">
