### PR TITLE
EP-48872: Code changes related to presentation of vulnerability report on docker registry ui

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -74,6 +74,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     ></tag-history-element>
   </material-card>
   
+  <material-card>
+    <h2>&nbsp;&nbsp;<i class="material-icons">notes</i>&nbsp; Vulnerability Report </h2>
+    <table id="dataTable">
+      <thead>
+          <tr>
+              <th></th>
+              <th>Package</th>
+              <th>Vulnerabilities</th>
+          </tr>
+      </thead>
+      <tbody>
+          <!-- Data rows will be inserted here -->
+      </tbody>
+    </table>
+  </material-card>
+
   <material-card each="{element in state.envelements}">
     <h2>&nbsp;&nbsp;<i class="material-icons">notes</i>&nbsp; ENV </h2>
     <image-label
@@ -92,17 +108,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
    ></image-label>
   </material-card>
 
-  <material-card each="{reportelements in state.reportelements}">
-    <h2>&nbsp;&nbsp;<i class="material-icons">notes</i>&nbsp; Vulnerability Report </h2>
-    <material-card each="{element in reportelements}">
-    <image-label
-      each="{ entry in element }"
-      if="{ entry.value && entry.value.length > 0}"
-      entry="{ entry }"
-    ></image-label>
-    </material-card>
-  </material-card>
-
   <script>
     import { DockerImage } from '../../scripts/docker-image';
     import { bytesToSize } from '../../scripts/utils';
@@ -110,6 +115,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import router from '../../scripts/router';
     import TagHistoryElement from './tag-history-element.riot';
     import ImageLabel from './image-label.riot';
+    const sevMap = {};
+      sevMap["UNSPECIFIED"] = 0;
+      sevMap["LOW"] = 1;
+      sevMap["MEDIUM"] = 2;
+      sevMap["HIGH"] = 3;
+      sevMap["CRITICAL"] = 4;
+      
     export default {
       components: {
         TagHistoryElement,
@@ -157,7 +169,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.image.variants[idx].fillInfo();;
         state.image.variants[idx].on('blobs', this.processBlobs);
       },
-
       async fetchReport(family, image, tag) {
         const queryParams = new URLSearchParams({ family, image, tag }).toString();
         const backend_url = `https://ep-pokeball.netskope.io/api/report?${queryParams}`;
@@ -166,10 +177,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           const response = await fetch(backend_url);
           const data = await response.json();
           return data;
-
         } catch (error) {
           console.error('Error fetching data:', error);
-          return []
+          return [];
         }
       },
       async processBlobs(blobs) {
@@ -197,7 +207,65 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           }
           return guiElements.sort(eltSort);
         }
-        const keySet = new Set(["VulnerabilityID", "PkgName", "InstalledVersion", "Severity"]);
+        // Function to populate the table with vulnerability report data
+        function populateTable(reportData) {
+          const data = reportData.Results[0]["Vulnerabilities"];
+          const pkgDict = {};
+          const cveDict = {};
+          data.forEach(item => {
+            if (item.PkgName in pkgDict) {
+              pkgDict[item.PkgName].push(item.VulnerabilityID);
+            } else {
+              pkgDict[item.PkgName] = [item.VulnerabilityID];
+            }
+            cveDict[item.VulnerabilityID] = item.Severity;
+          });
+          const tbody = document.querySelector('#dataTable tbody');
+          for (const [pkg, vulnerabilities] of Object.entries(pkgDict)) {
+            let sevArray = [0, 0, 0, 0, 0];
+            for (let vul of vulnerabilities) {
+              sevArray[Number(sevMap[cveDict[vul]])] += 1;
+            }
+            console.log("sevArray : ", sevArray);
+            // Create rectangles container
+            const rectContainer = document.createElement('div');
+            rectContainer.classList.add('rect-container');
+            sevArray.forEach(val => {
+                const rect = document.createElement('div');
+                rect.classList.add('rectangle');
+                rect.textContent = val;
+                rectContainer.appendChild(rect);
+            });
+            const mainRow = document.createElement('tr');
+            mainRow.innerHTML = `
+                <td class="expand-icon" >+</td>
+                <td>${pkg}</td>
+                <td style="text-align: center;"></td> <!-- Empty cell for rectangles -->
+            `;
+            mainRow.querySelector('td:nth-child(3)').appendChild(rectContainer);
+            tbody.appendChild(mainRow);
+            const expandableRows = [];
+            for (let idx = 0; idx < vulnerabilities.length; idx++) { // Adjust the number of rows as needed
+              const expandableRow = document.createElement('tr');
+              expandableRow.classList.add('expandable-row');
+              expandableRow.innerHTML = `
+                  <td></td> <!-- Empty cell for alignment -->
+                  <td>${vulnerabilities[idx]}</td>
+                  <td>${cveDict[vulnerabilities[idx]]}</td>
+              `;
+              tbody.appendChild(expandableRow);
+              expandableRows.push(expandableRow);
+            }
+            // Add click event listener to the "+" button
+            mainRow.querySelector('.expand-icon').addEventListener('click', function () {
+                const isExpanded = this.textContent === '-';
+                expandableRows.forEach(row => {
+                    row.style.display = isExpanded ? 'none' : 'table-row';
+                });
+                this.textContent = isExpanded ? '+' : '-'; // Toggle "+" to "-" to indicate expansion state
+            });
+          }
+        }
         const elements = new Array(1);
         elements[0] = exec(getConfig(blobs, { historyCustomLabels }));
         const reportData = await this.fetchReport(state.image.name.split("/")[0], state.image.name.split("/")[1], state.image.tag);
@@ -205,18 +273,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         if ('error' in reportData) {
           console.log("Error in downloading report. Please check existence of the report in artifactory");
         } else if (reportData.Results[0].hasOwnProperty("Vulnerabilities")) {
-          for (const vulnerability of reportData.Results[0]["Vulnerabilities"]) {
-            let tempArray = [];
-            for (const [key, value] of Object.entries(vulnerability)) {
-              let tempMap = {};
-              if (keySet.has(key)) {
-                tempMap["key"] = key;
-                tempMap["value"] = value;
-                tempArray.push(tempMap);
-              }
-            }
-            reportelements.push(tempArray);
-          }
+          populateTable(reportData);
         }
         this.update({
           elements,
@@ -224,7 +281,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
         this.state.labelelements.push(labelelements);
         this.state.envelements.push(envelements);
-        this.state.reportelements.push(reportelements);
         this.update();
       },
 
@@ -372,6 +428,69 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       display: flex;
       flex-direction: row;
       align-items: center;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background-color: #fff;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    }
+    th, td {
+      border: 1px solid #ddd;
+      padding: 12px;
+      text-align: center; /* Center content horizontally */
+      align-items: center;
+    }
+    th {
+      background-color: #f4f4f4;
+      text-align: center; /* Center content horizontally */
+      align-items: center;
+    }
+    .expand-icon {
+      cursor: pointer;
+      text-align: center;
+      padding: 0 5px;
+    }
+    #dataTable {
+      width: 100%; /* Ensure table takes full width of container */
+      table-layout: fixed; /* Ensures consistent column width */
+      text-align: center; /* Center content horizontally */
+    }
+    #dataTable td {
+      padding: 8px; /* Adjust padding as needed */
+      text-align: center; /* Center content horizontally */
+    }
+    #dataTable th {
+      padding: 8px; /* Adjust padding as needed */
+      text-align: center; /* Center-aligns text in table headers */
+    }
+    .expandable-row {
+      display: none; /* Hide expandable rows initially */
+    }
+    .expandable-row td:first-child {
+      padding-left: 20px; /* Indent expandable rows for visual hierarchy */
+    }
+    .rect-container {
+      display: flex; /* Align rectangles in a row */
+      gap: 4px; /* Space between rectangles */
+      justify-content: center; /* Horizontally centers the rectangles */
+      align-items: center; /* Vertically centers the rectangles */
+    }
+    .rectangle {
+      width: 20px; /* Width of each rectangle */
+      height: 20px; /* Height of each rectangle */
+      background-color: #FFFFFF;
+      color: black; /* Text color */
+      text-align: center; /* Center text */
+      line-height: 20px; /* Center text vertically */
+      border-radius: 3px; /* Rounded corners */
+      border: 1px solid #333; /* Border color */
+      box-shadow: 1px 1px 3px rgba(0,0,0,0.2); /* Shadow for 3D effect */
+    }
+    /* Set width for the first column */
+    #dataTable th:nth-child(1),
+    #dataTable td:nth-child(1) {
+      width: 10%;
     }
   </style>
 </tag-history>


### PR DESCRIPTION
EP-48872: Code changes related to presentation of vulnerability report on docker registry ui

Why this change was made -
We have vulnerability report information, which we now want to present to docker registry ui users in similar way the dockerhub website does. This PR addresses the same. 
This PR to be considered for basic structuring of vulnerability report information on tag history page. Please add review comments if you think, we are missing anything. 

**Note** - There are going to be few more enhancements on top of this PR to make UI better in terms of representation of vulnerability info. 
For e.g. https://netskope.atlassian.net/browse/EP-48970.

Feel free to add such suggestions/improvements on this PR or on ticket (EP-48872) 

What is the change -
html/js/css changes in tag-history.riot file

Testing -
PFA, screenshot of local testing . It shows overall how we will present vulnerability report info. in tabular structure. 

<img width="1222" alt="Screenshot 2024-08-12 at 3 43 14 PM" src="https://github.com/user-attachments/assets/3ca6767c-bfd4-4d50-ae2e-019fa95042cc">

