### PR TITLE
EP-49108: Code changes to provide hyperlink for cve ids in vulnerabil…

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -267,7 +267,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               expandableRow.classList.add('expandable-row');
               expandableRow.innerHTML = `
                   <td></td> <!-- Empty cell for alignment -->
-                  <td>${vulnerabilities[idx]}</td>
+                  <td><a href="https://scout.docker.com/vulnerabilities/id/${vulnerabilities[idx]}" target="_blank">${vulnerabilities[idx]}</a></td>
                   <td>${cveDict[vulnerabilities[idx]]}</td>
               `;
               tbody.appendChild(expandableRow);


### PR DESCRIPTION
Code changes to provide hyperlink for cve ids in vulnerability report

What have we changed - 
Html changes in tag-history.riot 

Testing - 
<img width="1116" alt="Screenshot 2024-08-14 at 9 36 15 PM" src="https://github.com/user-attachments/assets/0efaa960-b3ea-47c4-81ce-7fdcfc08af49">

Verified scout hyperlink getting opened in other tab.