### PR TITLE
EP-49421: Docker registry ui improvements

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -115,7 +115,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import router from '../../scripts/router';
     import TagHistoryElement from './tag-history-element.riot';
     import ImageLabel from './image-label.riot';
-    const colors = ['#8B1924', '#D52536', '#FBB552', '#FCE1A9', '#FFFFFF'];
+    const colors = ['#E65C00', '#FF751A', '#FF944D', '#FFB380', '#FFD1B3'];
     const tooltips = ['Critical severity', 'High severity', 'Medium severity', 'Low severity', 'Unspecified severity']; // Define tooltips
     const sevMap = {};
       sevMap["UNSPECIFIED"] = 4;
@@ -524,7 +524,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       background-color: #FFFFFF;
       color: black; /* Text color */
       text-align: center; /* Center text */
-      line-height: 20px; /* Center text vertically */
+      line-height: 25px; /* Center text vertically */
       border: 1px solid #333; /* Border color */
       box-shadow: 1px 1px 3px rgba(0,0,0,0.2); /* Shadow for 3D effect */
     }


### PR DESCRIPTION
Why this change was made -
Following code implements some of the suggestions @ns-ggeorgiev provided - 

1. Fix vertical alignement for digits inside rectangles. 
2. Dockerhub color codes should not be followed, @George Georgiev provided color codes should be implemented.
#FFD1B3
#FFB380
#FF944D
#FF751A
#E65C00

This PR addresses the same.
For more info and tracking - https://netskope.atlassian.net/browse/EP-49421

What have we changed -
Html/CSS/JS changes in tag-history.riot

Testing -

PFA, Images of local testing.

<img width="1175" alt="Screenshot 2024-08-20 at 10 13 54 AM" src="https://github.com/user-attachments/assets/74be5ebe-2269-41cd-bb20-e06d4eeeb64d">
