### PR TITLE
EP-49643: Fix for images with 0 vulnerabilities

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -238,17 +238,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             noVulnerabilityContainer.classList.add('hidden');
             noReportContainer.classList.remove('hidden');
             return
-          } else if (reportData.Results[0]["Vulnerabilities"].length === 0) {
+          } else if (reportData.Results[0].hasOwnProperty("Vulnerabilities")) {
+            table.classList.remove('hidden');
+            noReportContainer.classList.add('hidden');
+            noVulnerabilityContainer.classList.add('hidden');
+          } else {
             table.classList.add('hidden');
             noVulnerabilityContainer.classList.remove('hidden');
             noReportContainer.classList.add('hidden');
             return
-          } else {
-            table.classList.remove('hidden');
-            noReportContainer.classList.add('hidden');
-            noVulnerabilityContainer.classList.add('hidden');
           }
-
           const data = reportData.Results[0]["Vulnerabilities"];
           const pkgDict = {};
           const cveDict = {};
@@ -317,7 +316,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         if ('error' in reportData) {
           console.log("Error in downloading report. Please check existence of the report in artifactory");
           populateTable(null);
-        } else if (reportData.Results[0].hasOwnProperty("Vulnerabilities")) {
+        } else {
           populateTable(reportData);
           const date1 = new Date(reportData.Image["CreatedAt"]);
           const date2 = new Date(reportData.TrivyDB["UpdatedAt"]);


### PR DESCRIPTION
Why this change was made -
When an image does not have any vulnerability typically vulnerability attribute itself will be missing from the resulting json. We missed this case, and continued to show empty table instead of vulnerability free image and respective text message. This PR addresses the same. 

For more info and tracking - https://netskope.atlassian.net/browse/EP-49643

What is the change -
js changes in tag-history.riot file

Testing -
PFA, screenshot of local testing .
<img width="1189" alt="Screenshot 2024-08-21 at 12 48 43 PM" src="https://github.com/user-attachments/assets/5b7120fe-6f66-4e52-8554-6075202b6529">
