### PR TITLE
EP-49712: Code changes to represent vulnerability info

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -273,7 +273,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             sevArray.forEach(val => {
                 const rect = document.createElement('div');
                 rect.classList.add('rectangle');
-                rect.textContent = val;
+                if (val === 0) {
+                  rect.textContent = null;
+                } else {
+                  rect.textContent = val;
+                }
                 rect.style.backgroundColor = colors[index];
                 rect.setAttribute('data-tooltip', tooltips[index] || 'No tooltip'); 
                 rectContainer.appendChild(rect);


### PR DESCRIPTION
Why this change was made -
We have explored multiple options to represent vulnerability info. the same are mentioned here - [EP-49421](https://netskope.atlassian.net/browse/EP-49421)
For now we want to go ahead with the option which we think looks better.
For more info and tracking - https://netskope.atlassian.net/browse/EP-49421

What is the change -
js changes in tag-history.riot file

Testing -
PFA, screenshot of local testing .
<img width="1180" alt="Screenshot 2024-08-22 at 10 09 05 AM" src="https://github.com/user-attachments/assets/5e0ec4b0-5309-48c7-a122-6bbf14bf1fb5">


[EP-49421]: https://netskope.atlassian.net/browse/EP-49421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ