### PR TITLE
EP-49701: Code changes to remove dockerfile button

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -29,17 +29,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <i class="material-icons">arrow_back</i>
       </material-button>
       <h2>History of { props.image }:{ props.tag } <i class="material-icons">history</i></h2>
-      <material-button
-        text-color="var(--accent-text)"
-        color="inherit"
-        waves-color="var(--hover-background)"
-        waves-center="true"
-        rounded="true"
-        outlined
-        onClick="{ showDockerfile }"
-      >
-        Dockerfile
-      </material-button>
     </div>
   </material-card>
   <div if="{ !state.loadend }" class="spinner-wrapper">


### PR DESCRIPTION
Why this change was made -
We want to remove DOCKERFILE button on tag-history page, as it does not have any functionality associated with it as of now. This PR addresses the same. 
For more info and tracking - https://netskope.atlassian.net/browse/EP-49701

What is the change -
html changes in tag-history.riot file

Testing -
PFA, screenshot of local testing , No dockerfile button on the top - right side.
<img width="1249" alt="Screenshot 2024-08-23 at 10 25 57 AM" src="https://github.com/user-attachments/assets/933e74a2-9aa7-435d-a6e5-4b6fb0d742f9">

