### PR TITLE
EP-49931: deprecated logic is corrected.

### DIFF
--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -128,7 +128,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       },
       checkImage(image) {
         let imageNameWithRepo = repoName+"/"+image ;
-        console.log("imageNameWithRepo",imageNameWithRepo);
         if (image) {
           if (image.includes("-recent")){
             return true;
@@ -136,7 +135,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
         for (var key in cache) {
           if (key.includes(imageNameWithRepo)) {
-            console.log("cache:"+key)
             return true;
           }
         }

--- a/src/components/catalog/catalog-element.riot
+++ b/src/components/catalog/catalog-element.riot
@@ -80,6 +80,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import { Http } from '../../scripts/http';
     import { matchSearch } from '../search-bar.riot';
     import { cache } from '../catalog/catalog.riot';
+    import { repoName } from '../catalog/catalog.riot';
     
     export default {
       onBeforeMount(props, state) {
@@ -126,13 +127,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       checkImage(image) {
+        let imageNameWithRepo = repoName+"/"+image ;
+        console.log("imageNameWithRepo",imageNameWithRepo);
         if (image) {
           if (image.includes("-recent")){
             return true;
           }
         }
         for (var key in cache) {
-          if (key.includes(image)) {
+          if (key.includes(imageNameWithRepo)) {
+            console.log("cache:"+key)
             return true;
           }
         }

--- a/src/components/catalog/catalog.riot
+++ b/src/components/catalog/catalog.riot
@@ -49,6 +49,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import { getRegistryServers } from '../../scripts/utils';
 
     const cache = {};
+    let repoName = "";
     let repo = [];
     let excludeImages = false;
 
@@ -78,8 +79,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       onMounted(props, state) {
         this.display(props, state);
         this.fetchRepositories(repo).then(repo => {
-            console.log("Populated array:", repo);
-            console.log("Length of array:", repo.length); // This should print the correct length
             let deprecatedImagesCount = 0
             for (let i = 0; i < repo.length; i++){
               if (repo[i]) {
@@ -94,13 +93,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               }
             }
             this.state.numberOfDeprecatedImages = deprecatedImagesCount;
-            console.log("Number of deprecated images: ", this.state.numberOfDeprecatedImages);
             this.update();
         }).catch(error => {
             console.error("Error:", error);
         });
-        var storedState = localStorage.getItem('checkboxChecked');
-        console.log("Stored State: ", storedState);        
+        var storedState = localStorage.getItem('checkboxChecked');      
         if (storedState !== null) {
           this.state.checkboxChecked = storedState === 'true';
           excludeImages = this.state.checkboxChecked;
@@ -115,13 +112,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         const backend_url = 'https://ep-pokeball.netskope.io/api/data';
         try {
           const response = await fetch(backend_url);
-          console.log(response);
           const data = await response.json();
-          console.log(data);
           for (const key in data) {
-            if (key.includes("ns-ep") || key.includes("ns-builder")) {
               cache[key] = data[key]; 
-            }
           }
         } catch (error) {
           console.error('Error fetching data:', error);
@@ -154,13 +147,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           withCredentials: props.isRegistrySecured,
         });
         this.fetchRepositories(cache).then(cache => {
-          console.log("Populated cache:", cache);
           oReq.addEventListener('load', function () {
             if (this.status === 200) {
               let repositories_1 = JSON.parse(this.responseText).repositories || [];
+              let pullUrl = props.pullUrl;
+              repoName = pullUrl.split("/")[1];
               if (excludeImages === true) {
                 for (let i = 0; i < repositories_1.length; i++){
-                    console.log(repositories_1[i]);
                     if (!repositories_1[i].includes("unlabeled") && !repositories_1[i].includes("action-push")) {
                       if (!repositories_1[i].includes("-recent")) {
                         let tflg = false;
@@ -226,7 +219,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
       },
     };
-    export { cache }; 
+    export { cache };
+    export { repoName }; 
   </script>
   <style>
     catalog {

--- a/src/components/docker-registry-ui.riot
+++ b/src/components/docker-registry-ui.riot
@@ -56,6 +56,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <catalog
           registry-url="{ state.registryUrl }"
           registry-name="{ state.name }"
+          pull-url="{ state.pullUrl }"
           catalog-elements-limit="{ state.catalogElementsLimit }"
           on-notify="{ notifySnackbar }"
           filter-results="{ state.filter }"

--- a/src/components/tag-list/tag-list.riot
+++ b/src/components/tag-list/tag-list.riot
@@ -29,8 +29,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <i class="material-icons">arrow_back</i>
       </material-button>
       <h2>
-        Tags of { props.image } <span if="{ checkImage(props.image) }" class="github-label label-red">Deprecated</span>
-        <div class="deprecated-loc-hint" if="{ checkImage(props.image) }"><br>This stream of images moved to - <span>{ getImageLocation(props.image) }</span></div>
+        Tags of { props.image } <span if="{ checkImage(props.pullUrl,props.image) }" class="github-label label-red">Deprecated</span>
+        <div class="deprecated-loc-hint" if="{ checkImage(props.pullUrl,props.image) }"><br>This stream of images moved to - <span>{ getImageLocation(props.image) }</span></div>
         
         <div class="source-hint">Sourced from { state.registryName + '/' + props.image }</div>
         <div class="item-count">{ state.tags.length } tags</div>
@@ -172,14 +172,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         oReq.send();
         state.asc = true;
       },
-      checkImage(image) {
-        if (image) {
+      checkImage(pullUrl,image) {
+        let repoName = pullUrl.split("/")[1];
+        let imageNameWithRepo = repoName +"/"+image;
+        if (imageNameWithRepo) {
           if (image.includes("-recent")){
             return true;
           }
         }
         for (var key in cache) {
-          if (key.includes(image)) {
+          if (key.includes(imageNameWithRepo)) {
             return true;
           }
         }


### PR DESCRIPTION
As we new repos tool, service. our deprecated logic worked fine with org-base-release-docker repo. Now it is showing incorrect due to checking name against org-base-release-docker instead of org-tool-release-docker repo.
Currently if you see golang-alpine-current is deprecated in ns-builder org-base-release docker
<img width="1708" alt="Screenshot 2024-08-28 at 11 34 26 AM" src="https://github.com/user-attachments/assets/2883145c-acf7-48c6-a4af-6f32e9f1ec44">

Now it is corrected
<img width="1541" alt="Screenshot 2024-08-28 at 5 11 15 PM" src="https://github.com/user-attachments/assets/05196616-c3dc-49c9-8ac6-7e5fceabf81f">

