### PR TITLE
EP-49771: Code changes to bring vulnerability overview to tag list page

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -112,14 +112,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import router from '../../scripts/router';
     import TagHistoryElement from './tag-history-element.riot';
     import ImageLabel from './image-label.riot';
-    const colors = ['#E65C00', '#FF751A', '#FF944D', '#FFB380', '#FFD1B3'];
-    const tooltips = ['Critical severity', 'High severity', 'Medium severity', 'Low severity', 'Unspecified severity']; // Define tooltips
-    const sevMap = {};
-      sevMap["UNSPECIFIED"] = 4;
-      sevMap["LOW"] = 3;
-      sevMap["MEDIUM"] = 2;
-      sevMap["HIGH"] = 1;
-      sevMap["CRITICAL"] = 0;
+    import { fetchReport, createRectanglesContainer, SEVERITY_MAP } from '../utility/utility';
     let shouldShowLastUpdated = false;
     export default {
       components: {
@@ -170,19 +163,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.image.variants[idx].fillInfo();;
         state.image.variants[idx].on('blobs', this.processBlobs);
       },
-      async fetchReport(family, image, tag) {
-        const queryParams = new URLSearchParams({ family, image, tag }).toString();
-        const backend_url = `https://ep-pokeball.netskope.io/api/report?${queryParams}`;
-        console.log(backend_url);
-        try {
-          const response = await fetch(backend_url);
-          const data = await response.json();
-          return data;
-        } catch (error) {
-          console.error('Error fetching data:', error);
-          return [];
-        }
-      },
+      
       async processBlobs(blobs) {
         const state = this.state;
         const { historyCustomLabels } = this.props;
@@ -252,26 +233,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           for (const [pkg, vulnerabilities] of Object.entries(pkgDict)) {
             let sevArray = [0, 0, 0, 0, 0];
             for (let vul of vulnerabilities) {
-              sevArray[Number(sevMap[cveDict[vul]])] += 1;
+              sevArray[Number(SEVERITY_MAP[cveDict[vul]])] += 1;
             }
             console.log("sevArray : ", sevArray);
-            // Create rectangles container
-            const rectContainer = document.createElement('div');
-            rectContainer.classList.add('rect-container');
-            let index = 0;
-            sevArray.forEach(val => {
-                const rect = document.createElement('div');
-                rect.classList.add('rectangle');
-                if (val === 0) {
-                  rect.textContent = null;
-                } else {
-                  rect.textContent = val;
-                }
-                rect.style.backgroundColor = colors[index];
-                rect.setAttribute('data-tooltip', tooltips[index] || 'No tooltip'); 
-                rectContainer.appendChild(rect);
-                index += 1;
-            });
+
+            const rectContainer = createRectanglesContainer(sevArray);
             const mainRow = document.createElement('tr');
             mainRow.innerHTML = `
                 <td class="expand-icon" >+</td>
@@ -304,7 +270,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
         const elements = new Array(1);
         elements[0] = exec(getConfig(blobs, { historyCustomLabels }));
-        const reportData = await this.fetchReport(state.image.name.split("/")[0], state.image.name.split("/")[1], state.image.tag);
+        const reportData = await fetchReport(state.image.name.split("/")[0], state.image.name.split("/")[1], state.image.tag);
         console.log("reportData", reportData);
         if ('error' in reportData) {
           console.log("Error in downloading report. Please check existence of the report in artifactory");
@@ -549,46 +515,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     .expandable-row td:first-child {
       padding-left: 20px; /* Indent expandable rows for visual hierarchy */
     }
-    .rect-container {
-      display: flex; /* Align rectangles in a row */
-      justify-content: center; /* Horizontally centers the rectangles */
-      align-items: center; /* Vertically centers the rectangles */
-    }
-    .rectangle {
-      width: 40px; /* Width of each rectangle */
-      height: 25px; /* Height of each rectangle */
-      background-color: #FFFFFF;
-      color: black; /* Text color */
-      text-align: center; /* Center text */
-      line-height: 25px; /* Center text vertically */
-      border: 1px solid #333; /* Border color */
-      box-shadow: 1px 1px 3px rgba(0,0,0,0.2); /* Shadow for 3D effect */
-    }
     /* Set width for the first column */
     #dataTable th:nth-child(1),
     #dataTable td:nth-child(1) {
       width: 10%;
-    }
-    .rectangle:hover::after {
-      content: attr(data-tooltip); /* Use the value of the data-tooltip attribute */
-      position: absolute;
-      bottom: 100%; /* Position above the rectangle */
-      left: 50%;
-      transform: translateX(-50%);
-      background-color: #333; /* Tooltip background color */
-      color: #FFF; /* Tooltip text color */
-      padding: 5px;
-      border-radius: 3px;
-      white-space: nowrap;
-      font-size: 12px;
-      opacity: 0;
-      transition: opacity 0.3s;
-      visibility: hidden; /* Hide initially */
-    }
-
-    .rectangle:hover::after {
-      opacity: 1;
-      visibility: visible;
     }
   </style>
 </tag-history>

--- a/src/components/tag-list/tag-table.riot
+++ b/src/components/tag-list/tag-table.riot
@@ -28,10 +28,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   ></confirm-delete-image>
   <material-card class="taglist">
     <table style="border: none; table-layout: fixed; width: 100%;"">
-      <col style="width: 25%" />
-    <col style="width: 25%" />
-    <col style="width: 25%" />
-    <col style="width: 25%" /> 
+    <col style="width: 20%" />
+    <col style="width: 20%" />
+    <col style="width: 20%" />
+    <col style="width: 20%" />
+    <col style="width: 20%" /> 
       <thead>
         <tr>
           <th
@@ -41,13 +42,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           >
             Tag
           </th>
-
           <th>
             Size
           </th>
-
-         <!-- <th id="image-content-digest-header" if="{ props.showContentDigest }">Content Digest</th> -->
+          <!-- <th id="image-content-digest-header" if="{ props.showContentDigest }">Content Digest</th> -->
           <th class="architectures">Arch</th>
+          <th class="vulnerabilities">Vulnerabilities</th>
           <th class="show-tag-history">History</th>
           <th
             class="remove-tag { state.toDelete.size > 0 && !state.singleDeleteAction ? 'delete' : '' }"
@@ -102,6 +102,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <td class="architectures">
             <architectures image="{ image }"></architectures>
           </td>
+          <td class="dynamic-data">
+            <!-- Placeholder or default content -->
+          </td>
           <td class="show-tag-history">
             <tag-history-button image="{ image }"></tag-history-button>
           </td>
@@ -132,10 +135,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import Architectures from './architectures.riot';
     import { matchSearch } from '../search-bar.riot';
     import ConfirmDeleteImage from '../dialogs/confirm-delete-image.riot';
+    import { fetchReport, createRectanglesContainer, SEVERITY_MAP } from '../utility/utility';
     const ACTION_CHECK_TO_DELETE = 'CHECK';
     const ACTION_UNCHECK_TO_DELETE = 'UNCHECK';
     const ACTION_DELETE_IMAGE = 'DELETE';
-
     export default {
       components: {
         ImageDate,
@@ -228,6 +231,33 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           selectedImage,
         });
       },
+      async onMounted(props, state) {
+        console.log("Total tags : ", props.tags.length);
+        const reports = {};
+        for (let i = 0, len = props.tags.length; i < len; i++) {
+          var reportData = await fetchReport(props.tags[i]["name"].split("/")[0], props.tags[i]["name"].split("/")[1], props.tags[i]["tag"]);
+          reports[i] = reportData;
+        }
+        console.log(reports);
+        const rows = document.querySelectorAll('tbody tr');
+        rows.forEach((row, reportIdx) => {
+          if ('error' in reports[reportIdx]) {
+            console.log("Error in downloading report. Please check existence of the report in artifactory");
+            row.querySelector('td.dynamic-data').textContent = "Vulnerabilty report is not available";
+          } else {
+            let sevArray = [0, 0, 0, 0, 0];
+            if (reports[reportIdx].Results[0].hasOwnProperty("Vulnerabilities")) {
+              const data = reports[reportIdx].Results[0]["Vulnerabilities"];
+              data.forEach(item => {
+                sevArray[Number(SEVERITY_MAP[item.Severity])] += 1;
+              });
+            }
+            console.log("sevArray : ", sevArray);
+            const rectContainer = createRectanglesContainer(sevArray);
+            row.querySelector('td.dynamic-data').appendChild(rectContainer);
+          }
+        });
+      },
       supportShiftKey(selectedImage, addOrRemove) {
         if (!this.state.selectedImage) {
           return selectedImage;
@@ -253,41 +283,38 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         }
       },
       onColumnClick(order) {
-    // Check if it's the first click on the column
-    if (!this.state.clicked) {
-      this.state.clicked = true;
-      // Set the sorting order based on the click
-      this.props.asc = order === 'material-card-th-sorted-ascending';
-      // Here you can perform the sorting based on the new order.
-      // Call a sorting function or update your data accordingly.
-      // For example:
-      // this.sortData(this.props.asc);
-    } else {
-      // If it's not the first click, toggle the sorting order
-      this.props.asc = !this.props.onReverseOrder();
-      // Here you can perform the sorting based on the new order.
-      // Call a sorting function or update your data accordingly.
-      // For example:
-      // this.sortData(this.props.asc);
-    }
-  },
+        // Check if it's the first click on the column
+        if (!this.state.clicked) {
+          this.state.clicked = true;
+          // Set the sorting order based on the click
+          this.props.asc = order === 'material-card-th-sorted-ascending';
+          // Here you can perform the sorting based on the new order.
+          // Call a sorting function or update your data accordingly.
+          // For example:
+          // this.sortData(this.props.asc);
+        } else {
+          // If it's not the first click, toggle the sorting order
+          this.props.asc = !this.props.onReverseOrder();
+          // Here you can perform the sorting based on the new order.
+          // Call a sorting function or update your data accordingly.
+          // For example:
+          // this.sortData(this.props.asc);
+        }
+      },
       onReverseOrder() {
         this.state.orderType = null;
         this.state.desc = false;
         this.props.onReverseOrder();
       },
       onPageReorder(type) {
-      if (!this.state.sizeClicked){
-         this.state.sizeClicked = true;
-     
-    } else {
-      this.update({
-          orderType: type,
-          desc: (this.state.orderType && this.state.orderType !== type) || !this.state.desc,
-        });
-      
-    }
-        
+        if (!this.state.sizeClicked){
+          this.state.sizeClicked = true;
+        } else {
+          this.update({
+            orderType: type,
+            desc: (this.state.orderType && this.state.orderType !== type) || !this.state.desc,
+          });
+        }
       },
       getPage(tags, page) {
         const sortedTags = getPage(tags, page, this.props.tagsPerPage);
@@ -305,9 +332,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       matchSearch,
     };
     export { ACTION_CHECK_TO_DELETE, ACTION_UNCHECK_TO_DELETE, ACTION_DELETE_IMAGE };
+
   </script>
   <style>
     tag-table table th.architectures {
+      text-align: center;
+    }
+    tag-table table th.vulnerabilities {
       text-align: center;
     }
   </style>

--- a/src/components/utility/rectangle-styles.css
+++ b/src/components/utility/rectangle-styles.css
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 kmore
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.rect-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+  
+.rectangle {
+    width: 40px;
+    height: 25px;
+    background-color: #FFFFFF;
+    color: black;
+    text-align: center;
+    line-height: 25px;
+    border: 1px solid #333;
+    box-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+}
+  
+.rectangle:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #333;
+    color: #FFF;
+    padding: 5px;
+    border-radius: 3px;
+    white-space: nowrap;
+    font-size: 12px;
+    opacity: 0;
+    transition: opacity 0.3s;
+    visibility: hidden;
+}
+  
+.rectangle:hover::after {
+    opacity: 1;
+    visibility: visible;
+}

--- a/src/components/utility/utility.js
+++ b/src/components/utility/utility.js
@@ -1,0 +1,53 @@
+// Copyright 2024 kmore
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import './rectangle-styles.css';
+
+export const COLORS = ['#E65C00', '#FF751A', '#FF944D', '#FFB380', '#FFD1B3'];
+export const TOOLTIPS = ['Critical severity', 'High severity', 'Medium severity', 'Low severity', 'Unspecified severity']; // Define tooltips
+export const SEVERITY_MAP = {};
+      SEVERITY_MAP["UNSPECIFIED"] = 4;
+      SEVERITY_MAP["LOW"] = 3;
+      SEVERITY_MAP["MEDIUM"] = 2;
+      SEVERITY_MAP["HIGH"] = 1;
+      SEVERITY_MAP["CRITICAL"] = 0;
+    
+export async function fetchReport(family, image, tag) {
+    const queryParams = new URLSearchParams({ family, image, tag }).toString();
+    const backend_url = `https://ep-pokeball.netskope.io/api/report?${queryParams}`;
+    console.log(backend_url);
+    try {
+      const response = await fetch(backend_url);
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error('Error fetching data:', error);
+      return [];
+    }
+}
+
+export function createRectanglesContainer(sevArray) {
+    // Create rectangles container
+    const rectContainer = document.createElement('div');
+    rectContainer.classList.add('rect-container');
+    sevArray.forEach((val, index) => {
+      const rect = document.createElement('div');
+      rect.classList.add('rectangle');
+      rect.textContent = val === 0 ? null : val;
+      rect.style.backgroundColor = COLORS[index];
+      rect.setAttribute('data-tooltip', TOOLTIPS[index] || 'No tooltip');
+      rectContainer.appendChild(rect);  
+    });
+    return rectContainer;
+}


### PR DESCRIPTION
Why this change was made -
We are furnishing package wise vulnerability report on tag-history page. We need to show its overview on tag-list so user gets glimpse of it and can make quick decision. This code addresses the same. 
We are also making code more object oriented so it could be reused from multiple places. 
For more info and tracking - https://netskope.atlassian.net/browse/EP-49771

What is the change -
html/js/css changes in tag-history.riot, tag-table.riot.
Added 2 new files - src/components/utility/rectangle-styles.css, src/components/utility/utility.js

Testing -
PFA, screenshot of local testing 

Test 1 - Image with tag having vulnerabilities 
<img width="1189" alt="Screenshot 2024-08-28 at 4 41 55 PM" src="https://github.com/user-attachments/assets/a2dad0e7-bf37-49e6-98df-5ddc8eae03e7">

Test 2 - Image with tag having no vulnerability report
<img width="1195" alt="Screenshot 2024-08-28 at 4 43 06 PM" src="https://github.com/user-attachments/assets/9cf59fd3-4bf1-447f-859a-d6abb8de4e85">

Test 3 - Image with multiple tags , few having vulnerabilities, few without vulnerability report
<img width="1212" alt="Screenshot 2024-08-28 at 4 46 35 PM" src="https://github.com/user-attachments/assets/eea83a81-232d-4abe-b84f-096a5f847fc9">
 



