### PR TITLE
EP-49712: Code changes to change background colors to represent vulnerability information

### DIFF
--- a/src/components/utility/utility.js
+++ b/src/components/utility/utility.js
@@ -15,6 +15,7 @@
 import './rectangle-styles.css';
 
 export const COLORS = ['#E65C00', '#FF751A', '#FF944D', '#FFB380', '#FFD1B3'];
+export const BACKGROUND_COLORS = ['#7a7a7a', '#929292', '#a9a9a9', '#c1c1c1', '#dadada'];
 export const TOOLTIPS = ['Critical severity', 'High severity', 'Medium severity', 'Low severity', 'Unspecified severity']; // Define tooltips
 export const SEVERITY_MAP = {};
       SEVERITY_MAP["UNSPECIFIED"] = 4;
@@ -44,8 +45,13 @@ export function createRectanglesContainer(sevArray) {
     sevArray.forEach((val, index) => {
       const rect = document.createElement('div');
       rect.classList.add('rectangle');
-      rect.textContent = val === 0 ? null : val;
-      rect.style.backgroundColor = COLORS[index];
+      if (val === 0) {
+        rect.textContent = null;
+        rect.style.backgroundColor = BACKGROUND_COLORS[index];
+      } else {
+        rect.textContent = val;
+        rect.style.backgroundColor = COLORS[index];
+      }
       rect.setAttribute('data-tooltip', TOOLTIPS[index] || 'No tooltip');
       rectContainer.appendChild(rect);  
     });


### PR DESCRIPTION
Why this change was made -
We are changing background colors for the rectangles (representing vulnerability information) .. So in case where we have 0 vulnerability of the given severity type, we will use background colors ( ['#7a7a7a', '#929292', '#a9a9a9', '#c1c1c1', '#dadada'] ) from left to right. 

Just to get idea of current scheme of things , please refer [link](https://ep-pokeball.netskope.io/#!/taglist/ns-ep/ubuntu2004-current)

What is the change -
JS code changes in src/components/utility/utility.js

Testing -
PFA, screenshot of local testing.

[
<img width="1175" alt="Screenshot 2024-09-02 at 12 41 04 PM" src="https://github.com/user-attachments/assets/6d885ef2-3e12-4949-8300-043628a36c48">
](url)

<img width="1206" alt="Screenshot 2024-09-02 at 3 01 00 PM" src="https://github.com/user-attachments/assets/ecc7589b-5d3a-45ce-8b49-c8226c30f30e">

