### PR TITLE
EP-50469: Code changes to fix images not loading tag history because of env unavailability

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -172,11 +172,16 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         const labelelements = temp.map(obj=>{
             return {key:obj[0],value:obj[1]}
         })
-        const env = this.state.image.blobs.config.Env;
-        const tmp = Object.values(env)
-        const envelements = tmp.map(obj=>{
+        const imageConfig = this.state.image.blobs.config;
+        console.log("Image Config : ", imageConfig);
+        var envelements = null;
+        if (imageConfig.hasOwnProperty("Env")) {
+          const env = this.state.image.blobs.config.Env;
+          const tmp = Object.values(env)
+          envelements = tmp.map(obj=>{
             return {key:obj.split("=")[0],value:obj.split("=")[1]}
-        })
+          })
+        }
         function exec(elt) {
           const guiElements = [];
           for (var attribute in elt) {
@@ -236,7 +241,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               sevArray[Number(SEVERITY_MAP[cveDict[vul]])] += 1;
             }
             console.log("sevArray : ", sevArray);
-
             const rectContainer = createRectanglesContainer(sevArray);
             const mainRow = document.createElement('tr');
             mainRow.innerHTML = `


### PR DESCRIPTION
Why this change was made -

Tag history page not loading for newly added image - busybox-current/tag/24.89.20
Link - https://ep-pokeball.netskope.io/api/report?family=ns-builder&image=busybox-current&tag=24.89.20

We don't have ENV available for this particular image, we are adding error handling for the same. So once we have images without env, we will show blank env section and page loading should work fine. 

For Details - https://netskope.atlassian.net/browse/EP-50469

What is the change -
JS code changes in tag-history.riot

Testing -
PFA, screenshot of local testing.
<img width="1175" alt="Screenshot 2024-09-04 at 12 15 41 PM" src="https://github.com/user-attachments/assets/ffdd6b60-0046-4e45-b97d-b17520c9e36d">
