### PR TITLE
EP-50869: hiding vulnerabilities tab and vulnerability report in history section in tool repo.

### DIFF
--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -125,6 +125,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.elements = [];
         state.labelelements = [];
         state.envelements = [];
+        state.pullUrl = ""
         const now = new Date();
         state.lastRefreshedTS = now.toISOString().split("T")[0];
         state.image = new DockerImage(props.image, props.tag, {
@@ -142,6 +143,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         state.image.on('list', this.multiArchList);
         const materialCard = document.getElementById('materialCard');
         console.log("tag:",props.pullUrl);
+        state.pullUrl = props.pullUrl;
 
         // Check if repoName is present and not empty
         if (!props.pullUrl.includes('tool')) {
@@ -286,20 +288,22 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         elements[0] = exec(getConfig(blobs, { historyCustomLabels }));
         const reportData = await fetchReport(state.image.name.split("/")[0], state.image.name.split("/")[1], state.image.tag);
         console.log("reportData", reportData);
-        if ('error' in reportData) {
-          console.log("Error in downloading report. Please check existence of the report in artifactory");
-          populateTable(null);
-        } else {
-          populateTable(reportData);
-          const date1 = new Date(reportData.Image["CreatedAt"]);
-          const date2 = new Date(reportData.TrivyDB["UpdatedAt"]);
-          // Compare the dates and pick the latest one
-          const latestDate = date1 > date2 ? date1 : date2;
-          // Format the latest date as a string if needed
-          const latestTimestamp = formatDateWithMonthName(latestDate);
-          //const latestTimestamp = latestDate.toISOString().split("T")[0];
-          state.lastRefreshedTS = latestTimestamp;
-          shouldShowLastUpdated = true;
+        if (!state.pullUrl.includes("tool")){
+          if ('error' in reportData) {
+            console.log("Error in downloading report. Please check existence of the report in artifactory");
+            populateTable(null);
+          } else {
+            populateTable(reportData);
+            const date1 = new Date(reportData.Image["CreatedAt"]);
+            const date2 = new Date(reportData.TrivyDB["UpdatedAt"]);
+            // Compare the dates and pick the latest one
+            const latestDate = date1 > date2 ? date1 : date2;
+            // Format the latest date as a string if needed
+            const latestTimestamp = formatDateWithMonthName(latestDate);
+            //const latestTimestamp = latestDate.toISOString().split("T")[0];
+            state.lastRefreshedTS = latestTimestamp;
+            shouldShowLastUpdated = true;
+          }
         }
         // Get the element
         const lastUpdatedElement = document.getElementById('last-updated');

--- a/src/components/tag-history/tag-history.riot
+++ b/src/components/tag-history/tag-history.riot
@@ -63,7 +63,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     ></tag-history-element>
   </material-card>
   
-  <material-card>
+  <material-card id="materialCard" style="display: none;" >
     <h2>&nbsp;&nbsp;<i class="material-icons">notes</i>&nbsp; Vulnerability Report <span id="last-updated" class="last-updated hidden">Last updated date: {state.lastRefreshedTS} </span></h2>
     <table id="dataTable">
       <thead>
@@ -113,6 +113,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     import TagHistoryElement from './tag-history-element.riot';
     import ImageLabel from './image-label.riot';
     import { fetchReport, createRectanglesContainer, SEVERITY_MAP } from '../utility/utility';
+    import { repoName } from '../catalog/catalog.riot';
     let shouldShowLastUpdated = false;
     export default {
       components: {
@@ -139,6 +140,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       onMounted(props, state) {
         state.image.on('blobs', this.processBlobs);
         state.image.on('list', this.multiArchList);
+        const materialCard = document.getElementById('materialCard');
+        console.log("tag:",props.pullUrl);
+
+        // Check if repoName is present and not empty
+        if (!props.pullUrl.includes('tool')) {
+            materialCard.style.display = 'block'; // Show material card if repoName is present
+        } else {
+            materialCard.style.display = 'none'; // Keep it hidden if repoName is absent
+        }
       },
       onTabChanged(arch, idx) {
         const state = this.state;

--- a/src/components/tag-list/tag-table.riot
+++ b/src/components/tag-list/tag-table.riot
@@ -27,12 +27,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     on-image-deleted="{ props.onImageDeleted }"
   ></confirm-delete-image>
   <material-card class="taglist">
-    <table style="border: none; table-layout: fixed; width: 100%;"">
-    <col style="width: 20%" />
-    <col style="width: 20%" />
-    <col style="width: 20%" />
-    <col style="width: 20%" />
-    <col style="width: 20%" /> 
+    <table style="border: none; table-layout: fixed; width: 100%;">
+    <col id="col1" style="width: 25%;" />
+    <col id="col2" style="width: 25%;" />
+    <col id="col3" style="width: 25%;" />
+    <col id="vulnerabilitiesColumn" style="width: 20%; display: none;" />
+    <col id="col4" style="width: 25%;" />
       <thead>
         <tr>
           <th
@@ -47,7 +47,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           </th>
           <!-- <th id="image-content-digest-header" if="{ props.showContentDigest }">Content Digest</th> -->
           <th class="architectures">Arch</th>
-          <th class="vulnerabilities">Vulnerabilities</th>
+          <th class="vulnerabilities" id="vulnerabilitiesHeader">Vulnerabilities</th>
           <th class="show-tag-history">History</th>
           <th
             class="remove-tag { state.toDelete.size > 0 && !state.singleDeleteAction ? 'delete' : '' }"
@@ -102,7 +102,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <td class="architectures">
             <architectures image="{ image }"></architectures>
           </td>
-          <td class="dynamic-data">
+          <td class="dynamic-data vulnerabilitiesColumn" id="vulnerabilitiesHeader" >
             <!-- Placeholder or default content -->
           </td>
           <td class="show-tag-history">
@@ -232,6 +232,34 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         });
       },
       async onMounted(props, state) {
+        const vulnerabilitiesColumn = document.querySelectorAll('.vulnerabilitiesColumn');
+        const vulnerabilitiesHeader = document.getElementById('vulnerabilitiesHeader');
+        const cols = ['col1', 'col2', 'col3', 'col4'].map(id => document.getElementById(id));
+        const isToolIncluded = props.pullUrl.includes('tool');
+        console.log("isToolIncluded:",isToolIncluded);
+        
+        if (isToolIncluded) {
+            // Hide vulnerabilities column header
+            vulnerabilitiesHeader.style.display = 'none';
+         
+
+            // Hide vulnerabilities data cells
+            vulnerabilitiesColumn.forEach(cell => cell.style.display = 'none');
+
+            // Adjust column widths
+            cols.forEach(col => col.style.width = '25%');
+          } else {
+              // Show vulnerabilities column header
+              vulnerabilitiesHeader.style.display = '';
+             
+
+              // Show vulnerabilities data cells
+              vulnerabilitiesColumn.forEach(cell => cell.style.display = '');
+
+              // Adjust column widths
+              cols.forEach(col => col.style.width = '20%');
+          }
+       
         console.log("Total tags : ", props.tags.length);
         const reports = {};
         for (let i = 0, len = props.tags.length; i < len; i++) {


### PR DESCRIPTION
Earlier with tool repo we are showing vulnerabilities col and report section
<img width="1727" alt="Screenshot 2024-09-12 at 5 58 48 PM" src="https://github.com/user-attachments/assets/c9521a1e-ab93-488f-a55a-87711a9e3584">
<img width="1727" alt="Screenshot 2024-09-12 at 5 59 03 PM" src="https://github.com/user-attachments/assets/13170cfe-e9f1-4d7c-a15d-e031b4ea6812">

After this code we are hiding vulnerabilities for tool-repo
<img width="1727" alt="Screenshot 2024-09-12 at 6 09 17 PM" src="https://github.com/user-attachments/assets/cec67950-dbda-413c-b70e-4c7964fd9274">

<img width="1727" alt="Screenshot 2024-09-12 at 6 09 25 PM" src="https://github.com/user-attachments/assets/5a6b85bb-c9be-4dbc-8d86-943a06562692">
