### PR TITLE
EP-57525: Code changes to add efficiency column to tag list page

### DIFF
--- a/src/components/tag-list/tag-table.riot
+++ b/src/components/tag-list/tag-table.riot
@@ -243,8 +243,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         const efficiencyColumn = document.querySelectorAll('.efficiencyColumn');
         const efficiencyHeader = document.getElementById('efficiencyHeader');
         const cols = ['col1', 'col2', 'col3', 'col4', 'efficiencyColumn'].map(id => document.getElementById(id));
-        const isToolIncluded = props.pullUrl.includes('tool');
-        console.log("isToolIncluded:",isToolIncluded);
         
         const diveReportsData = {};
         for (let i = 0, len = props.tags.length; i < len; i++) {
@@ -262,7 +260,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             row.querySelector('td.dive-dynamic-data').textContent = parseFloat(diveReportsData[idx].image.efficiencyScore).toFixed(2) * 100;
           }
         });
-
+        const isToolIncluded = props.pullUrl.includes('tool');
+        console.log("isToolIncluded:",isToolIncluded);
         if (isToolIncluded) {
             // Hide vulnerabilities column header
             vulnerabilitiesHeader.style.display = 'none';


### PR DESCRIPTION
Why this change was made -
These changes are to add efficiency data on tag list page . Backend was already prepared by Suhal. Also call to fetch data from backend was also there in utility/dive. 
We made some changes into riot framework files - when we fetch dive report data (async/) and addditional css related changes. 
By mistake as the main branch netskope@main was not protected from push. Commits got pushed directly, this is reference PR created to trigger GH workflows to deploy changes to production and also get changes referenced here.

commit/acabad4b8fabb1837345a2e186793cc85d344fc3 ( [link](https://github.com/netSkope/docker-registry-ui/commit/acabad4b8fabb1837345a2e186793cc85d344fc3) )
commit/3d4dcc132e3b592fd0702a53962f795988039f34 ( [link](https://github.com/netSkope/docker-registry-ui/commit/3d4dcc132e3b592fd0702a53962f795988039f34) )

 (https://netskope.atlassian.net/browse/EP-57525)


What is the change -
Changes are made in tag-list.riot file 

Testing - Please find snaps of all the tests performed for below cases .

Images with Non-visible display columns data

Images without Non-visible display columns data

Images with Efficiency = NA

Images with actual Efficiency value

<img width="1209" alt="Screenshot 2024-12-16 at 1 16 05 PM" src="https://github.com/user-attachments/assets/615f8a9c-1022-4d90-867d-e6f3da00d79b" />
<img width="1215" alt="Screenshot 2024-12-16 at 2 54 07 PM" src="https://github.com/user-attachments/assets/e8eea268-1bce-4fca-b067-4d68aed66768" />
<img width="1206" alt="Screenshot 2024-12-16 at 2 54 29 PM" src="https://github.com/user-attachments/assets/c0e0b1f3-3404-43ff-972d-e3d1c24521a7" />
