### PR TITLE
EP-57571: Code changes related to fix table getting stretched horizontally while loading is in progress

### DIFF
--- a/src/components/tag-list/tag-table.riot
+++ b/src/components/tag-list/tag-table.riot
@@ -27,13 +27,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     on-image-deleted="{ props.onImageDeleted }"
   ></confirm-delete-image>
   <material-card class="taglist">
-    <table style="border: none; table-layout: fixed; width: 100%;">
-    <col id="col1" style="width: var(--col-width);" />
-    <col id="col2" style="width: var(--col-width);" />
-    <col id="col3" style="width: var(--col-width);" />
-    <col id="vulnerabilitiesColumn" style="width: var(--col-width); display: none;" />
-    <col id="efficiencyColumn" style="width: var(--col-width);" />
-    <col id="col4" style="width: var(--col-width);" />
+    <table style="border: none; table-layout: fixed; width: 100%; overflow-x: hidden;">
+    <col id="col1" style="width: 14%;" />
+    <col id="col2" style="width: 14%;" />
+    <col id="col3" style="width: 14%;" />
+    <col id="vulnerabilitiesColumn" style="width: 14%;" />
+    <col id="efficiencyColumn" style="width: 14%;" />
+    <col id="col4" style="width: 14%;" />
       <thead>
         <tr>
           <th
@@ -263,45 +263,45 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         const isToolIncluded = props.pullUrl.includes('tool');
         console.log("isToolIncluded:",isToolIncluded);
         if (isToolIncluded) {
-            // Hide vulnerabilities column header
-            vulnerabilitiesHeader.style.display = 'none';
-            // Hide vulnerabilities data cells
-            vulnerabilitiesColumn.forEach(cell => cell.style.display = 'none');
+          // Hide vulnerabilities column header
+          vulnerabilitiesHeader.style.display = 'none';
+          // Hide vulnerabilities data cells
+          vulnerabilitiesColumn.forEach(cell => cell.style.display = 'none');
+          // Adjust column widths
+          cols.forEach(col => col.style.width = '20%');
+        } else {
+            // Show vulnerabilities column header
+            vulnerabilitiesHeader.style.display = '';
+            // Show vulnerabilities data cells
+            vulnerabilitiesColumn.forEach(cell => cell.style.display = '');
             // Adjust column widths
-            cols.forEach(col => col.style.width = '20%');
-          } else {
-              // Show vulnerabilities column header
-              vulnerabilitiesHeader.style.display = '';
-              // Show vulnerabilities data cells
-              vulnerabilitiesColumn.forEach(cell => cell.style.display = '');
-              // Adjust column widths
-              cols.forEach(col => col.style.width = '16%');
-              console.log("Total tags : ", props.tags.length);
-              const reports = {};
-              for (let i = 0, len = props.tags.length; i < len; i++) {
-                var reportData = await fetchReport(props.tags[i]["name"].split("/")[0], props.tags[i]["name"].split("/")[1], props.tags[i]["tag"]);
-                reports[i] = reportData;
-              }
-              console.log("Vulnerability reports data :- ", reports);
-              const rows = document.querySelectorAll('tbody tr');
-              rows.forEach((row, reportIdx) => {
-                if ('error' in reports[reportIdx]) {
-                  console.log("Error in downloading report. Please check existence of the report in artifactory");
-                  row.querySelector('td.dynamic-data').textContent = "Vulnerabilty report is not available";
-                } else {
-                  let sevArray = [0, 0, 0, 0, 0];
-                  if (reports[reportIdx].Results[0].hasOwnProperty("Vulnerabilities")) {
-                    const data = reports[reportIdx].Results[0]["Vulnerabilities"];
-                    data.forEach(item => {
-                      sevArray[Number(SEVERITY_MAP[item.Severity])] += 1;
-                    });
-                  }
-                  console.log("sevArray : ", sevArray);
-                  const rectContainer = createRectanglesContainer(sevArray);
-                  row.querySelector('td.dynamic-data').appendChild(rectContainer);
+            cols.forEach(col => col.style.width = '14%');
+            console.log("Total tags : ", props.tags.length);
+            const reports = {};
+            for (let i = 0, len = props.tags.length; i < len; i++) {
+              var reportData = await fetchReport(props.tags[i]["name"].split("/")[0], props.tags[i]["name"].split("/")[1], props.tags[i]["tag"]);
+              reports[i] = reportData;
+            }
+            console.log("Vulnerability reports data :- ", reports);
+            const rows = document.querySelectorAll('tbody tr');
+            rows.forEach((row, reportIdx) => {
+              if ('error' in reports[reportIdx]) {
+                console.log("Error in downloading report. Please check existence of the report in artifactory");
+                row.querySelector('td.dynamic-data').textContent = "Vulnerabilty report is not available";
+              } else {
+                let sevArray = [0, 0, 0, 0, 0];
+                if (reports[reportIdx].Results[0].hasOwnProperty("Vulnerabilities")) {
+                  const data = reports[reportIdx].Results[0]["Vulnerabilities"];
+                  data.forEach(item => {
+                    sevArray[Number(SEVERITY_MAP[item.Severity])] += 1;
+                  });
                 }
-              });
-          }
+                console.log("sevArray : ", sevArray);
+                const rectContainer = createRectanglesContainer(sevArray);
+                row.querySelector('td.dynamic-data').appendChild(rectContainer);
+              }
+            });
+        }
       },
       supportShiftKey(selectedImage, addOrRemove) {
         if (!this.state.selectedImage) {
@@ -382,7 +382,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <style>
     /* Define CSS variables for consistent values */
     :root {
-      --col-width: 20%;
+      --col-width: 14%;
+    }
+
+    /* Preventing horizontal scroll */
+    tag-table table {
+      overflow-x: hidden;
+      width: 100%;
     }
 
     /* Aligning all headers and data cells to center */


### PR DESCRIPTION
Why this change was made -
In one of our previous work, we did resizing of columns that are part of tag-list table. There multiple reasons because of which tables go beyond webpage window, thus requiring user to use horizontal scroll bar. 

i) Dynamic Content Injection: During the loading phase, if the content (like tags, size, or vulnerabilities) is still being fetched, columns might temporarily grow larger than expected, especially if the content doesn't fit within the predefined width.

ii) Asynchronous Data Loading: The table may be trying to adjust columns as it receives data, especially if some columns (like the Vulnerabilities or Efficiency columns) are populated after the table has initially loaded.

iii) Column Visibility: If the columns are changing their visibility (display: none or visibility: collapse) after the initial page load, this could lead to horizontal overflow because the table layout is shifting as columns are shown or hidden.

i) -> we checked, because we put default value while actual data being pulled in. 
ii) -> we cant avoid this.
iii) -> We defined the table attributes so that it does not overflow in any case, and resized our column width attribute. 

In our case, Our JS code (which picks up columns to show or not after lot of data preprocessing) So while this preprocessing is in progress the table looked like going out of the window and needing horizontal scroll. 

(https://netskope.atlassian.net/browse/EP-57571)

What is the change -
We made few css changes, (redefined column sizes and table attributes.

Testing - PFA.

<img width="1217" alt="Screenshot 2025-01-10 at 3 54 17 PM" src="https://github.com/user-attachments/assets/67fd4742-226a-4fa8-8a14-ecd8fd47932a" />
